### PR TITLE
Pickle fixes to envs on biomechanics branch.

### DIFF
--- a/mj_envs/envs/biomechanics/__init__.py
+++ b/mj_envs/envs/biomechanics/__init__.py
@@ -1,10 +1,12 @@
 from gym.envs.registration import register
 import os
 import numpy as np
+
+
 curr_dir = os.path.dirname(os.path.abspath(__file__))
 
-
 print("RS:> Registering Biomechanics Envs")
+
 # Finger-tip reaching ==============================
 register(id='FingerReachMotorFixed-v0',
             entry_point='mj_envs.envs.biomechanics.reach_v0:ReachEnvV0',
@@ -175,9 +177,9 @@ register(id='HandPenTwirlFixed-v0',
             entry_point='mj_envs.envs.biomechanics.pen_v0:PenTwirlFixedEnvV0',
             max_episode_steps=50,
             kwargs={
-                'frame_skip': 5,
                 'model_path': curr_dir+'/assets/hand/2nd_hand_pen.xml',
-                'normalize_act': True
+                'normalize_act': True,
+                'frame_skip': 5,
             }
     )
 
@@ -185,9 +187,9 @@ register(id='HandPenTwirlRandom-v0',
             entry_point='mj_envs.envs.biomechanics.pen_v0:PenTwirlRandomEnvV0',
             max_episode_steps=50,
             kwargs={
-                'frame_skip': 5,
                 'model_path': curr_dir+'/assets/hand/2nd_hand_pen.xml',
-                'normalize_act': True
+                'normalize_act': True,
+                'frame_skip': 5,
             }
     )
 
@@ -198,7 +200,7 @@ register(id='BaodingFixed-v1',
             kwargs={
                 'model_path': curr_dir+'/assets/hand/2nd_hand_baoding.xml',
                 'normalize_act': True,
-                'reward_option':0
+                'reward_option': 0,
             }
     )
 register(id='BaodingFixed4th-v1',
@@ -207,7 +209,7 @@ register(id='BaodingFixed4th-v1',
             kwargs={
                 'model_path': curr_dir+'/assets/hand/2nd_hand_baoding.xml',
                 'normalize_act': True,
-                'reward_option':1
+                'reward_option': 1,
             }
     )
 register(id='BaodingFixed8th-v1',
@@ -216,6 +218,6 @@ register(id='BaodingFixed8th-v1',
             kwargs={
                 'model_path': curr_dir+'/assets/hand/2nd_hand_baoding.xml',
                 'normalize_act': True,
-                'reward_option':2
+                'reward_option': 2,
             }
     )

--- a/mj_envs/envs/biomechanics/baoding_v1.py
+++ b/mj_envs/envs/biomechanics/baoding_v1.py
@@ -1,11 +1,14 @@
+import collections
+import enum
+import gym
+import mujoco_py
+import numpy as np
+
 from mj_envs.envs.biomechanics.base_v0 import BaseV0
 from mj_envs.envs.env_base import get_sim
-import numpy as np
-import collections
 from mj_envs.utils.quatmath import euler2quat
 from mj_envs.utils.vectormath import calculate_cosine
-import enum
-import mujoco_py
+
 
 
 ## Define the task enum
@@ -31,13 +34,41 @@ class BaodingFixedEnvV1(BaseV0):
     }
 
     def __init__(self,
-                reward_option:int = 1,
+                model_path:str,
+                normalize_act:bool,
+                reward_option:int,
                 obs_keys:list = DEFAULT_OBS_KEYS,
-                rwd_keys_wt:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
 
-        self.sim = get_sim(model_path=kwargs['model_path'])
-        self.sim_obsd = get_sim(model_path=kwargs['model_path'])
+        # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
+        # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
+        # at the leaf level, when we do inheritance like we do here.
+        # kwargs is needed at the top level to account for injection of __class__ keyword.
+        # Also see: https://github.com/openai/gym/pull/1497
+        gym.utils.EzPickle.__init__(**locals())
+
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
+        # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
+        # created in __init__ to complete the setup.
+        super().__init__(model_path=model_path)
+
+        self._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    reward_option=reward_option, 
+                    rwd_viz=False)
+
+
+    def _setup(self,
+            obs_keys:list,
+            weighted_reward_keys:dict,
+            normalize_act,
+            reward_option,
+            rwd_viz,
+        ):
 
         # user parameters
         self.reward_option = reward_option
@@ -64,7 +95,10 @@ class BaodingFixedEnvV1(BaseV0):
         self.target1_sid = self.sim.model.site_name2id('target1_site')
         self.target2_sid = self.sim.model.site_name2id('target2_site')
 
-        super().__init__(obs_keys=obs_keys, rwd_keys_wt=rwd_keys_wt, sim=self.sim, sim_obsd=self.sim_obsd, rwd_viz=False, **kwargs)
+        super()._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    rwd_viz=rwd_viz)
 
 
     def step(self, a):

--- a/mj_envs/envs/biomechanics/base_v0.py
+++ b/mj_envs/envs/biomechanics/base_v0.py
@@ -1,21 +1,26 @@
 from mj_envs.envs import env_base
 from mujoco_py import MjViewer
 import numpy as np
+import gym
 
 class BaseV0(env_base.MujocoEnv):
 
-    def __init__(self, sim=None, sim_obsd=None, model_path=None, # model details
-                    sites:tuple = None, # fingertip sites of interests
-                    obs_keys:list=None,
-                    frame_skip = 10,
-                    **kwargs):
+    def __init__(self, model_path):
+        super().__init__(model_path)
 
-        # get sim
-        if sim is None:
-            sim = env_base.get_sim(model_path=model_path)
-            sim_obsd = env_base.get_sim(model_path=model_path)
+    def _setup(self,
+            obs_keys:list,
+            weighted_reward_keys:dict,
+            sites:list = None,
+            frame_skip = 10,
+            seed = None,
+            is_hardware = False,
+            config_path = None,
+            rwd_viz = False,
+            normalize_act = True,
+        ):
 
-        if sim.model.na>0 and 'act' not in obs_keys:
+        if self.sim.model.na>0 and 'act' not in obs_keys:
             obs_keys.append('act')
 
         # ids
@@ -23,27 +28,22 @@ class BaseV0(env_base.MujocoEnv):
         self.target_sids = []
         if sites:
             for site in sites:
-                self.tip_sids.append(sim.model.site_name2id(site))
-                self.target_sids.append(sim.model.site_name2id(site+'_target'))
-
-        # get env
-        env_base.MujocoEnv.__init__(self,
-                                sim = sim,
-                                sim_obsd = sim_obsd,
-                                model_path = model_path,
-                                frame_skip = frame_skip,
-                                config_path = None,
-                                obs_keys = obs_keys,
-                                rwd_mode = "dense",
-                                act_mode = "pos",
-                                act_normalized = True,
-                                is_hardware = False,
-                                **kwargs)
+                self.tip_sids.append(self.sim.model.site_name2id(site))
+                self.target_sids.append(self.sim.model.site_name2id(site+'_target'))
+        
+        super()._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    frame_skip=frame_skip, 
+                    seed=seed, 
+                    is_hardware=is_hardware,
+                    config_path=config_path,
+                    rwd_viz=rwd_viz,
+                    normalize_act=normalize_act)
 
 
     # step the simulation forward
     def step(self, a):
-        if self.act_normalized:
+        if self.normalize_act:
             a = 1.0/(1.0+np.exp(-5.0*(a-0.5)))
         return super().step(a=a)
 

--- a/mj_envs/envs/biomechanics/key_turn_v0.py
+++ b/mj_envs/envs/biomechanics/key_turn_v0.py
@@ -1,7 +1,9 @@
-from mj_envs.envs.biomechanics.base_v0 import BaseV0
-from mj_envs.envs.env_base import get_sim
-import numpy as np
 import collections
+import numpy as np
+import gym
+
+from mj_envs.envs.biomechanics.base_v0 import BaseV0
+
 
 class KeyTurnFixedEnvV0(BaseV0):
 
@@ -15,17 +17,43 @@ class KeyTurnFixedEnvV0(BaseV0):
     }
 
     def __init__(self,
+                model_path:str,
+                normalize_act:bool,
                 obs_keys:list = DEFAULT_OBS_KEYS,
-                rwd_keys_wt:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
 
-        self.sim = get_sim(model_path=kwargs['model_path'])
-        self.sim_obsd = get_sim(model_path=kwargs['model_path'])
+        # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
+        # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
+        # at the leaf level, when we do inheritance like we do here.
+        # kwargs is needed at the top level to account for injection of __class__ keyword.
+        # Also see: https://github.com/openai/gym/pull/1497
+        gym.utils.EzPickle.__init__(**locals())
+
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
+        # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
+        # created in __init__ to complete the setup.
+        super().__init__(model_path=model_path)
+
+        self._setup(obs_keys=obs_keys, weighted_reward_keys=weighted_reward_keys, normalize_act=normalize_act, rwd_viz=False)
+
+    def _setup(self,
+            obs_keys:list,
+            weighted_reward_keys:dict,
+            normalize_act,
+            rwd_viz,
+        ):
         self.keyhead_sid = self.sim.model.site_name2id("keyhead")
         self.IF_sid = self.sim.model.site_name2id("IFtip")
-        self.TH_sid = self.sim.model.site_name2id("THtip")
-        super().__init__(obs_keys=obs_keys, rwd_keys_wt=rwd_keys_wt, sim=self.sim, sim_obsd=self.sim_obsd, rwd_viz=False, **kwargs)
-        # self.init_qpos = self.sim.model.key_qpos[0]
+        self.TH_sid = self.sim.model.site_name2id("THtip")   
+        # self.init_qpos = self.sim.model.key_qpos[0]    
+
+        super()._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    rwd_viz=rwd_viz)
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/biomechanics/obj_hold_v0.py
+++ b/mj_envs/envs/biomechanics/obj_hold_v0.py
@@ -1,7 +1,9 @@
-from mj_envs.envs.biomechanics.base_v0 import BaseV0
-from mj_envs.envs.env_base import get_sim
-import numpy as np
 import collections
+import numpy as np
+import gym
+
+from mj_envs.envs.biomechanics.base_v0 import BaseV0
+
 
 class ObjHoldFixedEnvV0(BaseV0):
 
@@ -13,15 +15,46 @@ class ObjHoldFixedEnvV0(BaseV0):
     }
 
     def __init__(self,
+                model_path:str,
+                normalize_act:bool,
                 obs_keys:list = DEFAULT_OBS_KEYS,
-                rwd_keys_wt:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
 
-        self.sim = get_sim(model_path=kwargs['model_path'])
-        self.sim_obsd = get_sim(model_path=kwargs['model_path'])
+        # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
+        # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
+        # at the leaf level, when we do inheritance like we do here.
+        # kwargs is needed at the top level to account for injection of __class__ keyword.
+        # Also see: https://github.com/openai/gym/pull/1497
+        gym.utils.EzPickle.__init__(**locals())
+
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
+        # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
+        # created in __init__ to complete the setup.
+        super().__init__(model_path=model_path)
+
+        self._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    rwd_viz=False)
+
+    def _setup(self,
+            obs_keys:list,
+            weighted_reward_keys:dict,
+            normalize_act,
+            rwd_viz,
+        ):
+
         self.object_sid = self.sim.model.site_name2id("object")
         self.goal_sid = self.sim.model.site_name2id("goal")
-        super().__init__(obs_keys=obs_keys, rwd_keys_wt=rwd_keys_wt, sim=self.sim, sim_obsd=self.sim_obsd, rwd_viz=False, **kwargs)
+
+        super()._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    rwd_viz=rwd_viz)
+
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/biomechanics/pen_v0.py
+++ b/mj_envs/envs/biomechanics/pen_v0.py
@@ -1,10 +1,12 @@
-from os import sendfile
+import collections
+import numpy as np
+import gym 
+
 from mj_envs.envs.biomechanics.base_v0 import BaseV0
 from mj_envs.envs.env_base import get_sim
 from mj_envs.utils.quatmath import euler2quat
 from mj_envs.utils.vectormath import calculate_cosine
-import numpy as np
-import collections
+from os import sendfile
 
 class PenTwirlFixedEnvV0(BaseV0):
 
@@ -18,12 +20,40 @@ class PenTwirlFixedEnvV0(BaseV0):
     }
 
     def __init__(self,
+                model_path:str,
+                normalize_act:bool,
+                frame_skip:int,
                 obs_keys:list = DEFAULT_OBS_KEYS,
-                rwd_keys_wt:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
 
-        self.sim = get_sim(model_path=kwargs['model_path'])
-        self.sim_obsd = get_sim(model_path=kwargs['model_path'])
+        # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
+        # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
+        # at the leaf level, when we do inheritance like we do here.
+        # kwargs is needed at the top level to account for injection of __class__ keyword.
+        # Also see: https://github.com/openai/gym/pull/1497
+        gym.utils.EzPickle.__init__(**locals())
+
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
+        # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
+        # created in __init__ to complete the setup.
+        super().__init__(model_path=model_path)
+
+        self._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    frame_skip=frame_skip, 
+                    rwd_viz=False)
+
+    def _setup(self,
+            obs_keys:list,
+            weighted_reward_keys:dict,
+            normalize_act,
+            frame_skip,
+            rwd_viz,
+        ):
 
         self.target_obj_bid = self.sim.model.body_name2id("target")
         self.S_grasp_sid = self.sim.model.site_name2id('S_grasp')
@@ -35,7 +65,12 @@ class PenTwirlFixedEnvV0(BaseV0):
         self.tar_b_sid = self.sim.model.site_name2id('target_bottom')
         self.pen_length = np.linalg.norm(self.sim.model.site_pos[self.obj_t_sid] - self.sim.model.site_pos[self.obj_b_sid])
         self.tar_length = np.linalg.norm(self.sim.model.site_pos[self.tar_t_sid] - self.sim.model.site_pos[self.tar_b_sid])
-        super().__init__(obs_keys=obs_keys, rwd_keys_wt=rwd_keys_wt, sim=self.sim, sim_obsd=self.sim_obsd, rwd_viz=False, **kwargs)
+
+        super()._setup(obs_keys=obs_keys, 
+            weighted_reward_keys=weighted_reward_keys, 
+            normalize_act=normalize_act, 
+            rwd_viz=rwd_viz,
+            frame_skip=frame_skip)
 
     def get_obs_vec(self):
         # qpos for hand, xpos for obj, xpos for target

--- a/mj_envs/envs/biomechanics/reach_v0.py
+++ b/mj_envs/envs/biomechanics/reach_v0.py
@@ -1,6 +1,10 @@
-from mj_envs.envs.biomechanics.base_v0 import BaseV0
-import numpy as np
 import collections
+import gym
+import numpy as np
+
+from mj_envs.envs.biomechanics.base_v0 import BaseV0
+
+
 
 class ReachEnvV0(BaseV0):
 
@@ -12,12 +16,51 @@ class ReachEnvV0(BaseV0):
     }
 
     def __init__(self,
+                model_path:str,
+                target_reach_range:dict,
                 obs_keys:list = DEFAULT_OBS_KEYS,
-                rwd_keys_wt:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                target_reach_range:dict = {'IFtip': ((0.2, 0.05, 0.20), (0.2, 0.05, 0.20)),},
-                **kwargs):
+                weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                **kwargs,
+            ):
+
+        # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
+        # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
+        # at the leaf level, when we do inheritance like we do here.
+        # kwargs is needed at the top level to account for injection of __class__ keyword.
+        # Also see: https://github.com/openai/gym/pull/1497
+        gym.utils.EzPickle.__init__(**locals())
+
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
+        # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
+        # created in __init__ to complete the setup.
+        super().__init__(model_path=model_path)
+        
+        self._setup(target_reach_range=target_reach_range, 
+                obs_keys=obs_keys, 
+                weighted_reward_keys=weighted_reward_keys)
+
+
+    def _setup(self,
+            target_reach_range:dict,
+            obs_keys:list,
+            weighted_reward_keys:dict,
+            frame_skip = 10,
+            seed = None,
+            is_hardware = False,
+            config_path = None,
+        ):
+
         self.target_reach_range = target_reach_range
-        super().__init__(obs_keys=obs_keys, rwd_keys_wt=rwd_keys_wt, sites=self.target_reach_range.keys(), **kwargs)
+
+        super()._setup(obs_keys=obs_keys, 
+                weighted_reward_keys=weighted_reward_keys, 
+                sites=self.target_reach_range.keys(), 
+                frame_skip=frame_skip, 
+                seed=seed, 
+                is_hardware=is_hardware, 
+                config_path=config_path)
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/env_base.py
+++ b/mj_envs/envs/env_base.py
@@ -1,15 +1,13 @@
-import os
-from re import A
-from xml.dom import InvalidStateErr
 import gym
 import numpy as np
-import six
+import os
 import time as timer
 
 from mj_envs.utils.obj_vec_dict import ObsVecDict
 from mj_envs.robot.robot import Robot
 from os import path
-
+from re import A
+from xml.dom import InvalidStateErr
 
 # TODO
 # remove rwd_mode

--- a/mj_envs/envs/env_base.py
+++ b/mj_envs/envs/env_base.py
@@ -1,16 +1,14 @@
 import os
-
-from gym import error, spaces
-# from gym.utils import seeding
-from gym import utils
-from mj_envs.utils.obj_vec_dict import ObsVecDict
-from mj_envs.robot.robot import Robot
-import numpy as np
-from os import path
+from re import A
+from xml.dom import InvalidStateErr
 import gym
+import numpy as np
 import six
 import time as timer
 
+from mj_envs.utils.obj_vec_dict import ObsVecDict
+from mj_envs.robot.robot import Robot
+from os import path
 
 
 # TODO
@@ -21,7 +19,7 @@ try:
     import mujoco_py
     from mujoco_py import load_model_from_path, MjSim, MjViewer, load_model_from_xml, ignore_mujoco_warnings
 except ImportError as e:
-    raise error.DependencyNotInstalled("{}. (HINT: you need to install mujoco_py, and also perform the setup instructions here: https://github.com/openai/mujoco-py/.)".format(e))
+    raise gym.error.DependencyNotInstalled("{}. (HINT: you need to install mujoco_py, and also perform the setup instructions here: https://github.com/openai/mujoco-py/.)".format(e))
 
 def get_sim(model_path:str=None, model_xmlstr=None):
     """
@@ -42,77 +40,77 @@ def get_sim(model_path:str=None, model_xmlstr=None):
 
     return MjSim(model)
 
-class MujocoEnv(gym.Env, utils.EzPickle, ObsVecDict):
+class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
     """
     Superclass for all MuJoCo environments.
     """
 
-    def __init__(self,
-                sim = None,             # true dynamics (used for simulation)
-                sim_obsd = None,        # observed dynamics (used to reconstruct (partially observed) sim from (noisy)sensor data)
-                model_path = None,      # xml to use to generate sim + sim_obsd
-                frame_skip = 1,         # frame_skip
-                obs_keys = None,        # keys from obs_dict to use
-                rwd_keys_wt = None,     # {keys, wt} from rwd_dict to use
-                rwd_mode = "dense",     # dense / sparse
-                act_normalized = True,  # use normalized actions
-                seed = None,            # seed the random number generator
-                obs_range = (-10, 10),  # obs_range (used to define obs_space)
-                *args, **kwargs):
+    def __init__(self, model_path):
+        self.sim = get_sim(model_path)
+        self.sim_obsd = get_sim(model_path)
+        ObsVecDict.__init__(self)
 
-        # resolve sim
-        if sim is None:
-            self.sim = get_sim(model_path)
-            self.sim_obsd = get_sim(model_path)
-        else:
-            assert sim_obsd is not None, "sim and sim_obsd needs to be specified together, else model_path should be provided"
-            self.sim = sim
-            self.sim_obsd = sim_obsd
+    def _setup(self,
+            obs_keys,
+            weighted_reward_keys,
+            reward_mode = "dense",             
+            frame_skip = 1,
+            normalize_act = True,
+            obs_range = (-10, 10),
+            seed = None,
+            act_mode = "pos",
+            is_hardware = False,
+            config_path = None,
+            rwd_viz = False,
+        ):
+
+        if self.sim is None or self.sim_obsd is None:
+            raise InvalidStateErr("sim and sim_obsd must be instantiated for setup to run")
 
         # seed the random number generator
         self.seed(seed)
         self.mujoco_render_frames = False
+        self.rwd_viz = rwd_viz
 
         # resolve robot config
-        self.robot = Robot(
-                mj_sim = self.sim,
-                random_generator = self.np_random,
-                *args, **kwargs)
+        self.robot = Robot(mj_sim=self.sim, 
+                        random_generator=self.np_random, 
+                        act_mode=act_mode,
+                        is_hardware=is_hardware,
+                        config_path = config_path,
+                    )
 
-        # resolve act
+        #resolve action space
         self.frame_skip = frame_skip
-        self.act_normalized = act_normalized
-        act_low = -np.ones(self.sim.model.nu) if self.act_normalized else self.sim.model.actuator_ctrlrange[:,0].copy()
-        act_high = np.ones(self.sim.model.nu) if self.act_normalized else self.sim.model.actuator_ctrlrange[:,1].copy()
-        self.action_space = spaces.Box(act_low, act_high, dtype=np.float32)
+        self.normalize_act = normalize_act
+        act_low = -np.ones(self.sim.model.nu) if self.normalize_act else self.sim.model.actuator_ctrlrange[:,0].copy()
+        act_high = np.ones(self.sim.model.nu) if self.normalize_act else self.sim.model.actuator_ctrlrange[:,1].copy()
+        self.action_space = gym.spaces.Box(act_low, act_high, dtype=np.float32)
 
         # resolve rewards
         self.rwd_dict = {}
-        self.rwd_mode = rwd_mode
-        self.rwd_keys_wt = rwd_keys_wt
+        self.rwd_mode = reward_mode
+        self.rwd_keys_wt = weighted_reward_keys
 
         # resolve obs
         self.obs_dict = {}
         self.obs_keys = obs_keys
-        ObsVecDict.__init__(self)
         observation, _reward, done, _info = self.step(np.zeros(self.sim.model.nu))
         assert not done, "Checking initialization. Simulation starts in a done state."
         self.obs_dim = observation.size
-        self.observation_space = spaces.Box(obs_range[0]*np.ones(self.obs_dim), obs_range[1]*np.ones(self.obs_dim), dtype=np.float32)
+        self.observation_space = gym.spaces.Box(obs_range[0]*np.ones(self.obs_dim), obs_range[1]*np.ones(self.obs_dim), dtype=np.float32)
 
         # resolve initial state
         self.init_qvel = self.sim.data.qvel.ravel().copy()
         self.init_qpos = self.sim.data.qpos.ravel().copy() # has issues with initial jump during reset
-        # self.init_qpos = np.mean(self.sim.model.actuator_ctrlrange, axis=1) if self.act_normalized else self.sim.data.qpos.ravel().copy() # has issues when nq!=nu
-        # self.init_qpos[self.sim.model.jnt_dofadr] = np.mean(self.sim.model.jnt_range, axis=1) if self.act_normalized else self.sim.data.qpos.ravel().copy()
-        if self.act_normalized:
+        # self.init_qpos = np.mean(self.sim.model.actuator_ctrlrange, axis=1) if self.normalize_act else self.sim.data.qpos.ravel().copy() # has issues when nq!=nu
+        # self.init_qpos[self.sim.model.jnt_dofadr] = np.mean(self.sim.model.jnt_range, axis=1) if self.normalize_act else self.sim.data.qpos.ravel().copy()
+        if self.normalize_act:
             linear_jnt_qposids = self.sim.model.jnt_qposadr[self.sim.model.jnt_type>1] #hinge and slides
             linear_jnt_ids = self.sim.model.jnt_type>1
             self.init_qpos[linear_jnt_qposids] = np.mean(self.sim.model.jnt_range[linear_jnt_ids], axis=1)
 
-        # finalize init
-        utils.EzPickle.__init__(self)
-
+        return 
 
     def step(self, a):
         """
@@ -121,7 +119,7 @@ class MujocoEnv(gym.Env, utils.EzPickle, ObsVecDict):
         """
         a = np.clip(a, self.action_space.low, self.action_space.high)
         self.last_ctrl = self.robot.step(ctrl_desired=a,
-                                        ctrl_normalized=self.act_normalized,
+                                        ctrl_normalized=self.normalize_act,
                                         step_duration=self.dt,
                                         realTimeSim=self.mujoco_render_frames,
                                         render_cbk=self.mj_render if self.mujoco_render_frames else None)
@@ -249,7 +247,7 @@ class MujocoEnv(gym.Env, utils.EzPickle, ObsVecDict):
         """
         Set random number seed
         """
-        self.np_random, seed = utils.seeding.np_random(seed)
+        self.np_random, seed = gym.utils.seeding.np_random(seed)
         return [seed]
 
 

--- a/mj_envs/robot/robot.py
+++ b/mj_envs/robot/robot.py
@@ -42,7 +42,7 @@ class Robot():
                 sensor_cache_maxsize = 5,   # cache size for sensors
                 noise_scale = 0,            # scale for sensor noise
                 random_generator = None,    # random number generator
-                *args, **kwargs):
+            ):
 
         self.name = robot_name+'(sim)' if is_hardware is None else robot_name+'(hdr)'
         self._act_mode = act_mode

--- a/mj_envs/tests/envs/biomechanics/test_biomechanics.py
+++ b/mj_envs/tests/envs/biomechanics/test_biomechanics.py
@@ -1,0 +1,36 @@
+import gym
+import mj_envs.envs.biomechanics
+import pickle
+import pytest
+
+GYM_ENVIRONMENT_IDS = (
+    'FingerReachMotorFixed-v0',
+    'FingerReachMotorRandom-v0',
+    'FingerReachMuscleFixed-v0',
+    'FingerReachMuscleRandom-v0',
+    'FingerPoseMotorFixed-v0',
+    'FingerPoseMotorRandom-v0',
+    'FingerPoseMuscleFixed-v0',
+    'FingerPoseMuscleRandom-v0',
+    'IFTHPoseMuscleRandom-v0',
+    'HandPoseAMuscleFixed-v0',
+    'IFTHKeyTurnFixed-v0',
+    'IFTHKeyTurnRandom-v0',
+    'HandObjHoldFixed-v0',
+    'HandObjHoldRandom-v0',
+    'HandPenTwirlFixed-v0',
+    'HandPenTwirlRandom-v0',
+    'BaodingFixed-v1',
+    'BaodingFixed4th-v1',
+    'BaodingFixed8th-v1',
+)
+
+
+@pytest.mark.parametrize("environment_id", GYM_ENVIRONMENT_IDS)
+def test_serialize_deserialize(environment_id):
+    env1 = gym.make(environment_id)
+    env2 = pickle.loads(pickle.dumps(env1))
+
+    assert env1.action_space == env2.action_space, (
+        env1.action_space, env2.action_space)
+


### PR DESCRIPTION
## WHAT
This pull request addresses pickling issues in environments in biomechanics branch. Following environments have been fixed.

```
    'FingerReachMotorFixed-v0',
    'FingerReachMotorRandom-v0',
    'FingerReachMuscleFixed-v0',
    'FingerReachMuscleRandom-v0',
    'FingerPoseMotorFixed-v0',
    'FingerPoseMotorRandom-v0',
    'FingerPoseMuscleFixed-v0',
    'FingerPoseMuscleRandom-v0',
    'IFTHPoseMuscleRandom-v0',
    'HandPoseAMuscleFixed-v0',
    'IFTHKeyTurnFixed-v0',
    'IFTHKeyTurnRandom-v0',
    'HandObjHoldFixed-v0',
    'HandObjHoldRandom-v0',
    'HandPenTwirlFixed-v0',
    'HandPenTwirlRandom-v0',
    'BaodingFixed-v1',
    'BaodingFixed4th-v1',
    'BaodingFixed8th-v1',
 ```
 
 ## WHY
 * During training, we would like to be able to use mujoco envs across process boundaries in Python multiprocessing setup. 
 * This means these environments have to be pickle friendly.
 
 ## HOW
 * All our environments are extensions of OpenAI Gym envs, specifically, `gym.Env`
 * All our environments extend `gym.utils.EzPickle`
 * We have a base class `mj_envs.envs.env_base.MujocoEnv` that extends `gym.Env` and `gym.utils.EzPickle`
 * Before this change we were instantiating `sim` and `sim_obsd` objects outside of `mj_envs.envs.env_base.MujocoEnv` , say in derived classed like `BaseV0` or `ReachV0`. This won't work.
 * Reason being `sim` object is not really picklable. It has a lot of native dependencies and it cannot be really serialized and deserialized in the context of python multiprocessing.
 * We need to pass `model_path` all the way into `mj_envs.envs.env_base.MujocoEnv` and instantiate `sim / sim_obsd` inside of `mj_envs.envs.env_base.MujocoEnv`
 * However a lot our envs, require `sim / sim_obsd` to setup things in derived class constructors which in turn is required by `mj_envs.envs.env_base.MujocoEnv` constructor. 
 * This dependency chain means we need two phase construction in our envs. First we go through and create `sim / sim_obsd` in `mj_envs.envs.env_base.MujocoEnv` 
 * Then in `_setup` we use these objects to complete the initialization of our envs.
 
 ## TEST
 * Added `tests/envs/biomechanics/test_biomechanics.py` to test pickling of envs.
 
 ```
 (mjrl-env) giriman@devfair0439:~/ubuntu/rl/mj_envs/mj_envs/tests/envs$ pytest biomechanics/test_biomechanics.py 
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.7.10, pytest-5.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/giriman/ubuntu/rl/mj_envs
plugins: hydra-core-1.1.0rc1
collected 19 items                                                                                                                                                                                                           

biomechanics/test_biomechanics.py ...................                                                                                                                                                                  [100%]

====================================================================================================== warnings summary ======================================================================================================
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:26: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    _MAX_FLOAT = np.maximum_sctype(np.float)

mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:27: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    _FLOAT_EPS = np.finfo(np.float).eps

mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMotorFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMotorRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHPoseMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPoseAMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHKeyTurnFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHKeyTurnRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandObjHoldFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandObjHoldRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPenTwirlFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPenTwirlRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed-v1]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed4th-v1]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed8th-v1]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/gym/logger.py:30: UserWarning: WARN: Box bound precision lowered by casting to float32
    warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================== 19 passed, 21 warnings in 10.54 seconds ===========================================================================================
```
 
 