### PR TITLE
Robustifying pickle tests

### DIFF
--- a/mj_envs/envs/biomechanics/__init__.py
+++ b/mj_envs/envs/biomechanics/__init__.py
@@ -127,7 +127,7 @@ register(id='HandPoseAMuscleFixed-v0',
                 'viz_site_targets': ('THtip','IFtip','MFtip','RFtip','LFtip'),
                 'target_jnt_value': np.array([0, 0, 0, -0.0904, 0.0824475, -0.681555, -0.514888, 0, -0.013964, -0.0458132, 0, 0.67553, -0.020944, 0.76979, 0.65982, 0, 0, 0, 0, 0.479155, -0.099484, 0.95831, 0]),
                 'normalize_act': False,
-                'reset_type': "none",        # none, init, random
+                'reset_type': "init",        # none, init, random
                 'target_type': 'fixed',      # switch / generate/ fixed
             }
     )

--- a/mj_envs/envs/biomechanics/__init__.py
+++ b/mj_envs/envs/biomechanics/__init__.py
@@ -127,7 +127,7 @@ register(id='HandPoseAMuscleFixed-v0',
                 'viz_site_targets': ('THtip','IFtip','MFtip','RFtip','LFtip'),
                 'target_jnt_value': np.array([0, 0, 0, -0.0904, 0.0824475, -0.681555, -0.514888, 0, -0.013964, -0.0458132, 0, 0.67553, -0.020944, 0.76979, 0.65982, 0, 0, 0, 0, 0.479155, -0.099484, 0.95831, 0]),
                 'normalize_act': False,
-                'reset_type': "random",        # none, init, random
+                'reset_type': "none",        # none, init, random
                 'target_type': 'fixed',      # switch / generate/ fixed
             }
     )

--- a/mj_envs/envs/biomechanics/baoding_v1.py
+++ b/mj_envs/envs/biomechanics/baoding_v1.py
@@ -37,6 +37,7 @@ class BaodingFixedEnvV1(BaseV0):
                 model_path:str,
                 normalize_act:bool,
                 reward_option:int,
+                seed = None,
                 obs_keys:list = DEFAULT_OBS_KEYS,
                 weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
@@ -59,7 +60,8 @@ class BaodingFixedEnvV1(BaseV0):
                     weighted_reward_keys=weighted_reward_keys, 
                     normalize_act=normalize_act, 
                     reward_option=reward_option, 
-                    rwd_viz=False)
+                    rwd_viz=False,
+                    seed=seed)
 
 
     def _setup(self,
@@ -68,6 +70,7 @@ class BaodingFixedEnvV1(BaseV0):
             normalize_act,
             reward_option,
             rwd_viz,
+            seed,
         ):
 
         # user parameters
@@ -98,7 +101,8 @@ class BaodingFixedEnvV1(BaseV0):
         super()._setup(obs_keys=obs_keys, 
                     weighted_reward_keys=weighted_reward_keys, 
                     normalize_act=normalize_act, 
-                    rwd_viz=rwd_viz)
+                    rwd_viz=rwd_viz,
+                    seed=seed)
 
 
     def step(self, a):

--- a/mj_envs/envs/biomechanics/key_turn_v0.py
+++ b/mj_envs/envs/biomechanics/key_turn_v0.py
@@ -19,6 +19,7 @@ class KeyTurnFixedEnvV0(BaseV0):
     def __init__(self,
                 model_path:str,
                 normalize_act:bool,
+                seed = None,
                 obs_keys:list = DEFAULT_OBS_KEYS,
                 weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
@@ -37,13 +38,18 @@ class KeyTurnFixedEnvV0(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(obs_keys=obs_keys, weighted_reward_keys=weighted_reward_keys, normalize_act=normalize_act, rwd_viz=False)
+        self._setup(obs_keys=obs_keys, 
+                    weighted_reward_keys=weighted_reward_keys, 
+                    normalize_act=normalize_act, 
+                    rwd_viz=False, 
+                    seed=seed)
 
     def _setup(self,
             obs_keys:list,
             weighted_reward_keys:dict,
             normalize_act,
             rwd_viz,
+            seed,
         ):
         self.keyhead_sid = self.sim.model.site_name2id("keyhead")
         self.IF_sid = self.sim.model.site_name2id("IFtip")
@@ -53,7 +59,8 @@ class KeyTurnFixedEnvV0(BaseV0):
         super()._setup(obs_keys=obs_keys, 
                     weighted_reward_keys=weighted_reward_keys, 
                     normalize_act=normalize_act, 
-                    rwd_viz=rwd_viz)
+                    rwd_viz=rwd_viz,
+                    seed=seed)
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/biomechanics/obj_hold_v0.py
+++ b/mj_envs/envs/biomechanics/obj_hold_v0.py
@@ -17,6 +17,7 @@ class ObjHoldFixedEnvV0(BaseV0):
     def __init__(self,
                 model_path:str,
                 normalize_act:bool,
+                seed = None,
                 obs_keys:list = DEFAULT_OBS_KEYS,
                 weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
@@ -38,13 +39,15 @@ class ObjHoldFixedEnvV0(BaseV0):
         self._setup(obs_keys=obs_keys, 
                     weighted_reward_keys=weighted_reward_keys, 
                     normalize_act=normalize_act, 
-                    rwd_viz=False)
+                    rwd_viz=False,
+                    seed=seed)
 
     def _setup(self,
             obs_keys:list,
             weighted_reward_keys:dict,
             normalize_act,
             rwd_viz,
+            seed,
         ):
 
         self.object_sid = self.sim.model.site_name2id("object")
@@ -53,7 +56,8 @@ class ObjHoldFixedEnvV0(BaseV0):
         super()._setup(obs_keys=obs_keys, 
                     weighted_reward_keys=weighted_reward_keys, 
                     normalize_act=normalize_act, 
-                    rwd_viz=rwd_viz)
+                    rwd_viz=rwd_viz,
+                    seed=seed)
 
 
     def get_obs_vec(self):

--- a/mj_envs/envs/biomechanics/pen_v0.py
+++ b/mj_envs/envs/biomechanics/pen_v0.py
@@ -23,6 +23,7 @@ class PenTwirlFixedEnvV0(BaseV0):
                 model_path:str,
                 normalize_act:bool,
                 frame_skip:int,
+                seed = None,
                 obs_keys:list = DEFAULT_OBS_KEYS,
                 weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs):
@@ -45,7 +46,8 @@ class PenTwirlFixedEnvV0(BaseV0):
                     weighted_reward_keys=weighted_reward_keys, 
                     normalize_act=normalize_act, 
                     frame_skip=frame_skip, 
-                    rwd_viz=False)
+                    rwd_viz=False,
+                    seed=seed)
 
     def _setup(self,
             obs_keys:list,
@@ -53,6 +55,7 @@ class PenTwirlFixedEnvV0(BaseV0):
             normalize_act,
             frame_skip,
             rwd_viz,
+            seed,
         ):
 
         self.target_obj_bid = self.sim.model.body_name2id("target")
@@ -70,7 +73,8 @@ class PenTwirlFixedEnvV0(BaseV0):
             weighted_reward_keys=weighted_reward_keys, 
             normalize_act=normalize_act, 
             rwd_viz=rwd_viz,
-            frame_skip=frame_skip)
+            frame_skip=frame_skip,
+            seed=seed)
 
     def get_obs_vec(self):
         # qpos for hand, xpos for obj, xpos for target

--- a/mj_envs/envs/biomechanics/pose_v0.py
+++ b/mj_envs/envs/biomechanics/pose_v0.py
@@ -16,6 +16,7 @@ class PoseEnvV0(BaseV0):
 
     def __init__(self,
                 model_path:str,
+                seed = None, 
                 viz_site_targets:tuple = None,  # site to use for targets visualization []
                 target_jnt_range:dict = None,   # joint ranges as tuples {name:(min, max)}_nq
                 target_jnt_value:list = None,   # desired joint vector [des_qpos]_nq
@@ -46,6 +47,7 @@ class PoseEnvV0(BaseV0):
                 target_type=target_type,
                 obs_keys=obs_keys,
                 weighted_reward_keys=weighted_reward_keys,
+                seed=seed,
             )
 
     def _setup(self,
@@ -126,9 +128,9 @@ class PoseEnvV0(BaseV0):
 
     # generate a valid target pose
     def get_target_pose(self):
-        if self.target_type is "fixed":
+        if self.target_type == "fixed":
             return self.target_jnt_value
-        elif self.target_type is "generate":
+        elif self.target_type == "generate":
             return self.np_random.uniform(high=self.target_jnt_range[:,0], low=self.target_jnt_range[:,1])
         else:
             raise TypeError("Unknown Target type: {}".format(self.target_type))
@@ -155,10 +157,10 @@ class PoseEnvV0(BaseV0):
     def reset(self):
 
         # update target
-        if self.target_type is "generate":
+        if self.target_type == "generate":
             # use target_jnt_range to generate targets
             self.update_target(restore_sim=True)
-        elif self.target_type is "switch":
+        elif self.target_type == "switch":
             # switch between given target choices
             # TODO: Remove hard-coded numbers
             if self.target_jnt_value[0] != -0.145125:
@@ -173,16 +175,16 @@ class PoseEnvV0(BaseV0):
         elif self.target_type is "fixed":
             self.update_target(restore_sim=True)
         else:
-            print("Target Type not found")
+            print("{} Target Type not found ".format(self.target_type))
 
         # update init state
-        if self.reset_type is "none" or self.reset_type is None:
+        if self.reset_type is None or self.reset_type == "none":
             # no reset; use last state
             obs = self.get_obs()
-        elif self.reset_type is "init":
+        elif self.reset_type == "init":
             # reset to init state
             obs = super().reset()
-        elif self.reset_type is "random":
+        elif self.reset_type == "random":
             # reset to random state
             jnt_init = self.np_random.uniform(high=self.sim.model.jnt_range[:,1], low=self.sim.model.jnt_range[:,0])
             obs = super().reset(reset_qpos=jnt_init)

--- a/mj_envs/envs/biomechanics/reach_v0.py
+++ b/mj_envs/envs/biomechanics/reach_v0.py
@@ -18,6 +18,7 @@ class ReachEnvV0(BaseV0):
     def __init__(self,
                 model_path:str,
                 target_reach_range:dict,
+                seed = None,
                 obs_keys:list = DEFAULT_OBS_KEYS,
                 weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
                 **kwargs,
@@ -39,7 +40,8 @@ class ReachEnvV0(BaseV0):
         
         self._setup(target_reach_range=target_reach_range, 
                 obs_keys=obs_keys, 
-                weighted_reward_keys=weighted_reward_keys)
+                weighted_reward_keys=weighted_reward_keys,
+                seed=seed)
 
 
     def _setup(self,

--- a/mj_envs/tests/envs/biomechanics/test_biomechanics.py
+++ b/mj_envs/tests/envs/biomechanics/test_biomechanics.py
@@ -1,9 +1,10 @@
 import gym
 import mj_envs.envs.biomechanics
+import numpy
 import pickle
 import pytest
 
-GYM_ENVIRONMENT_IDS = (
+ENVIRONMENT_IDS = (
     'FingerReachMotorFixed-v0',
     'FingerReachMotorRandom-v0',
     'FingerReachMuscleFixed-v0',
@@ -26,11 +27,38 @@ GYM_ENVIRONMENT_IDS = (
 )
 
 
-@pytest.mark.parametrize("environment_id", GYM_ENVIRONMENT_IDS)
+
+@pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
 def test_serialize_deserialize(environment_id):
-    env1 = gym.make(environment_id)
+    env1 = gym.make(environment_id, seed=123)
+    obs_dict_1 = env1.get_obs_dict(env1.env.sim)
+    reward_dict_1 = env1.get_reward_dict(obs_dict_1)
+    assert len(obs_dict_1) > 0
+    assert len(reward_dict_1) > 0
+    obs = env1.env.get_obs()    
+    assert len(obs) > 0
+    infos1 = env1.env.get_env_infos()
+    assert len(infos1) > 0
+    
+    env1.reset()
+
     env2 = pickle.loads(pickle.dumps(env1))
+    env2.reset()
 
     assert env1.action_space == env2.action_space, (
-        env1.action_space, env2.action_space)
+        env1.action_space, env2.action_space
+    )
+    assert (env1.get_obs() == env2.get_obs()).all(), (
+        env1.get_obs(), env2.get_obs()
+    )
+
+    obs_dict_2 = env2.get_obs_dict(env2.env.sim)
+    reward_dict_2 = env2.get_reward_dict(obs_dict_2)
+    infos2 = env2.env.get_env_infos()
+    assert len(obs_dict_1) == len(obs_dict_2), (obs_dict_1, obs_dict_2)
+    assert len(reward_dict_1) == len(reward_dict_2), (reward_dict_1, reward_dict_2)  
+    assert len(infos1) == len(infos2), (infos1, infos2)
+
+    env1.env.step(numpy.zeros(env1.env.sim.model.nu))
+    env2.env.step(numpy.zeros(env2.env.sim.model.nu))
 


### PR DESCRIPTION
## WHAT 

These set of changes does a few things:

- We make `test_biomechanics` bit more robust by testing the unpickled env more thoroughly
- As part of this testing we discovered that `seed` had to be passed through correctly via `_init_` and `_setup` correctly to have reproducible results.
- Along the way we discovered some string compare bugs that are now fixed as well.

## TESTS

```
(mjrl-env) giriman@devfair0439:~/ubuntu/rl/mj_envs/mj_envs$ pytest tests/envs/biomechanics/test_biomechanics.py 
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.7.10, pytest-5.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/giriman/ubuntu/rl/mj_envs
plugins: hydra-core-1.1.0rc1
collected 19 items                                                                                                                                                                                                           

tests/envs/biomechanics/test_biomechanics.py ...................                                                                                                                                                       [100%]

====================================================================================================== warnings summary ======================================================================================================
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:26: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    _MAX_FLOAT = np.maximum_sctype(np.float)

mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:27: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    _FLOAT_EPS = np.finfo(np.float).eps

mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMotorFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMotorRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHPoseMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPoseAMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHKeyTurnFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHKeyTurnRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandObjHoldFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandObjHoldRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPenTwirlFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPenTwirlRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed-v1]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed4th-v1]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed8th-v1]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/gym/logger.py:30: UserWarning: WARN: Box bound precision lowered by casting to float32
    warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================== 19 passed, 21 warnings in 10.33 seconds ===========================================================================================
```