### PR TITLE
Fixing kwarg passing through init and setup in a pickle friendly way

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "dependencies/Adroit"]
 	path = mj_envs/sims/Adroit
 	url = https://github.com/vikashplus/Adroit.git
-        branch = mj_envs
+    branch = mj_envs
 [submodule "mj_envs/sims/furniture_sim"]
 	path = mj_envs/sims/furniture_sim
 	url = https://github.com/vikashplus/furniture_sim.git
@@ -23,7 +23,7 @@
 [submodule "mj_envs/sims/YCB_sim"]
 	path = mj_envs/sims/YCB_sim
 	url = https://github.com/vikashplus/YCB_sim.git
-		branch = main
+	branch = main
 [submodule "mj_envs/sims/neuromuscular_sim"]
 	path = mj_envs/sims/neuromuscular_sim
-	url = git@github.com:vikashplus/neuromuscular_sim.git
+	url = https://github.com/vikashplus/neuromuscular_sim.git

--- a/mj_envs/__init__.py
+++ b/mj_envs/__init__.py
@@ -1,8 +1,5 @@
-import  mj_envs.envs.hand_manipulation_suite
-import  mj_envs.envs.arms
-import  mj_envs.envs.relay_kitchen
-import  mj_envs.envs.fm
-import mj_envs.envs.hand_manipulation_suite
-import mj_envs.envs.biomechanics
-# import  mj_envs.envs.arms
-# import  mj_envs.envs.relay_kitchen
+import mj_envs.envs.arms # noqa
+import mj_envs.envs.biomechanics # noqa
+import mj_envs.envs.fm # noqa
+import mj_envs.envs.hand_manipulation_suite # noqa
+import mj_envs.envs.relay_kitchen # noqa

--- a/mj_envs/envs/arms/fetch/assets/fetch_reach_v0.config
+++ b/mj_envs/envs/arms/fetch/assets/fetch_reach_v0.config
@@ -1,7 +1,7 @@
 {
     # device1: sensors, actuators
     'franka':{
-        'interface': {'type': 'franka'},
+        'interface': {'type': 'fetch'},
         'sensor':[
             {'range':(-2.9, 2.9), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'shoulder_pan_jp'},
             {'range':(-1.8, 1.8), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'shoulder_lift_jp'},
@@ -12,16 +12,6 @@
             {'range':(-2.9, 2.9), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'wrist_roll_jp'},
             {'range':(0.00, .04), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'r_gripper_finger_jp'},
             {'range':(0.00, .04), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'l_gripper_finger_jp'},
-
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv1'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv2'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv3'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv4'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv5'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv6'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_arm_jv7'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_fin_jv1'},
-            # {'range':(-2*np.pi, np.pi), 'noise':0.05, 'hdr_id':-1, 'scale':1, 'offset':0, 'name':'fr_fin_jv2'},
         ],
 
         'actuator':[

--- a/mj_envs/envs/arms/push_base_v0.py
+++ b/mj_envs/envs/arms/push_base_v0.py
@@ -3,6 +3,7 @@ import gym
 import numpy as np
 
 from mj_envs.envs import env_base
+from pydantic import NoneStrBytes
 
 
 class PushBaseV0(env_base.MujocoEnv):
@@ -17,23 +18,14 @@ class PushBaseV0(env_base.MujocoEnv):
         "penalty": -50,
     }
 
-
-    def __init__(self, 
-                model_path, 
-                config_path, 
-                robot_site_name,
-                object_site_name,
-                target_site_name, 
-                target_xyz_range,
-                seed = None,
-                **kwargs):
+    def __init__(self, model_path, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -42,28 +34,17 @@ class PushBaseV0(env_base.MujocoEnv):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(config_path=config_path, 
-                    robot_site_name=robot_site_name, 
-                    object_site_name=object_site_name, 
-                    target_site_name=target_site_name, 
-                    target_xyz_range=target_xyz_range, 
-                    seed=seed)
+        self._setup(**kwargs)
 
 
     def _setup(self,
-            config_path, 
-            robot_site_name,
-            object_site_name,
-            target_site_name, 
-            target_xyz_range,
-            seed,
-            obs_keys:list = DEFAULT_OBS_KEYS,
-            weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-            frame_skip = 4,
-            reward_mode = "dense",
-            act_mode = "pos",
-            normalize_act = True,
-            is_hardware = False,
+               robot_site_name,
+               object_site_name,
+               target_site_name, 
+               target_xyz_range,
+               frame_skip=4,
+               reward_mode="dense",
+               **kwargs,
         ):
 
         # ids
@@ -72,14 +53,11 @@ class PushBaseV0(env_base.MujocoEnv):
         self.target_sid = self.sim.model.site_name2id(target_site_name)
         self.target_xyz_range = target_xyz_range
 
-        super()._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    reward_mode=reward_mode, 
-                    frame_skip=frame_skip, 
-                    normalize_act=normalize_act, 
-                    seed=seed, act_mode=act_mode, 
-                    is_hardware=is_hardware, 
-                    config_path=config_path)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       reward_mode=reward_mode, 
+                       frame_skip=frame_skip, 
+                       **kwargs)
 
     def get_obs_dict(self, sim):
         obs_dict = {}

--- a/mj_envs/envs/arms/push_base_v0.py
+++ b/mj_envs/envs/arms/push_base_v0.py
@@ -3,8 +3,6 @@ import gym
 import numpy as np
 
 from mj_envs.envs import env_base
-from pydantic import NoneStrBytes
-
 
 class PushBaseV0(env_base.MujocoEnv):
 
@@ -27,8 +25,8 @@ class PushBaseV0(env_base.MujocoEnv):
         # Also see: https://github.com/openai/gym/pull/1497
         gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
-        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
-        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we
         # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
         # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
         # created in __init__ to complete the setup.
@@ -40,7 +38,7 @@ class PushBaseV0(env_base.MujocoEnv):
     def _setup(self,
                robot_site_name,
                object_site_name,
-               target_site_name, 
+               target_site_name,
                target_xyz_range,
                frame_skip=4,
                reward_mode="dense",
@@ -53,10 +51,10 @@ class PushBaseV0(env_base.MujocoEnv):
         self.target_sid = self.sim.model.site_name2id(target_site_name)
         self.target_xyz_range = target_xyz_range
 
-        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
-                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
-                       reward_mode=reward_mode, 
-                       frame_skip=frame_skip, 
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS,
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                       reward_mode=reward_mode,
+                       frame_skip=frame_skip,
                        **kwargs)
 
     def get_obs_dict(self, sim):

--- a/mj_envs/envs/arms/reach_base_v0.py
+++ b/mj_envs/envs/arms/reach_base_v0.py
@@ -17,21 +17,14 @@ class ReachBaseV0(env_base.MujocoEnv):
     }
 
 
-    def __init__(self, 
-                model_path, 
-                config_path, 
-                robot_site_name,
-                target_site_name, 
-                target_xyz_range,
-                seed = None,
-                **kwargs):
+    def __init__(self, model_path, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -40,26 +33,16 @@ class ReachBaseV0(env_base.MujocoEnv):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(config_path=config_path, 
-            robot_site_name=robot_site_name, 
-            target_site_name=target_site_name, 
-            target_xyz_range=target_xyz_range, 
-            seed=seed)
+        self._setup(**kwargs)
 
 
     def _setup(self,
-            config_path, 
-            robot_site_name,
-            target_site_name, 
-            target_xyz_range,
-            seed,
-            obs_keys:list = DEFAULT_OBS_KEYS,
-            weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-            frame_skip = 40,
-            reward_mode = "dense",
-            act_mode = "pos",
-            normalize_act = True,
-            is_hardware = False,
+               robot_site_name,
+               target_site_name, 
+               target_xyz_range,
+               frame_skip = 40,
+               reward_mode = "dense",
+               **kwargs,
         ):
 
         # ids
@@ -67,14 +50,11 @@ class ReachBaseV0(env_base.MujocoEnv):
         self.target_sid = self.sim.model.site_name2id(target_site_name)
         self.target_xyz_range = target_xyz_range
 
-        super()._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    reward_mode=reward_mode, 
-                    frame_skip=frame_skip, 
-                    normalize_act=normalize_act, 
-                    seed=seed, act_mode=act_mode, 
-                    is_hardware=is_hardware, 
-                    config_path=config_path)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       reward_mode=reward_mode, 
+                       frame_skip=frame_skip, 
+                       **kwargs)
 
 
     def get_obs_dict(self, sim):

--- a/mj_envs/envs/arms/reach_base_v0.py
+++ b/mj_envs/envs/arms/reach_base_v0.py
@@ -26,8 +26,8 @@ class ReachBaseV0(env_base.MujocoEnv):
         # Also see: https://github.com/openai/gym/pull/1497
         gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
-        # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
-        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we
         # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
         # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
         # created in __init__ to complete the setup.
@@ -38,7 +38,7 @@ class ReachBaseV0(env_base.MujocoEnv):
 
     def _setup(self,
                robot_site_name,
-               target_site_name, 
+               target_site_name,
                target_xyz_range,
                frame_skip = 40,
                reward_mode = "dense",
@@ -50,10 +50,10 @@ class ReachBaseV0(env_base.MujocoEnv):
         self.target_sid = self.sim.model.site_name2id(target_site_name)
         self.target_xyz_range = target_xyz_range
 
-        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
-                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
-                       reward_mode=reward_mode, 
-                       frame_skip=frame_skip, 
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS,
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                       reward_mode=reward_mode,
+                       frame_skip=frame_skip,
                        **kwargs)
 
 

--- a/mj_envs/envs/biomechanics/__init__.py
+++ b/mj_envs/envs/biomechanics/__init__.py
@@ -8,275 +8,270 @@ curr_dir = os.path.dirname(os.path.abspath(__file__))
 print("RS:> Registering Biomechanics Envs")
 
 # Finger-tip reaching ==============================
-register(
-    id="FingerReachMotorFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.reach_v0:ReachEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_motorAct_v0.xml",
-        "target_reach_range": {
-            "IFtip": ((0.2, 0.05, 0.20), (0.2, 0.05, 0.20)),
-        },
-    },
-)
-register(
-    id="FingerReachMotorRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.reach_v0:ReachEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_motorAct_v0.xml",
-        "target_reach_range": {
-            "IFtip": ((0.27, 0.1, 0.3), (0.1, -0.1, 0.1)),
-        },
-    },
-)
-register(
-    id="FingerReachMuscleFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.reach_v0:ReachEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_muscleAct_v0.xml",
-        "target_reach_range": {
-            "IFtip": ((0.2, 0.05, 0.20), (0.2, 0.05, 0.20)),
-        },
-    },
-)
+register(id='FingerReachMotorFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.reach_v0:ReachEnvV0',
+            max_episode_steps=10,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_motorAct_v0.xml',
+                'target_reach_range': {'IFtip': ((0.2, 0.05, 0.20), (0.2, 0.05, 0.20)),},
+                'normalize_act': True
+            }
+    )
+register(id='FingerReachMotorRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.reach_v0:ReachEnvV0',
+            max_episode_steps=10,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_motorAct_v0.xml',
+                'target_reach_range': {'IFtip': ((0.27, .1, .3), (.1, -.1, .1)),},
+                'normalize_act': True
+            }
+    )
+register(id='FingerReachMuscleFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.reach_v0:ReachEnvV0',
+            max_episode_steps=10,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_muscleAct_v0.xml',
+                'target_reach_range': {'IFtip': ((0.2, 0.05, 0.20), (0.2, 0.05, 0.20)),},
+                'normalize_act': False,
+            }
+    )
 
-register(
-    id="FingerReachMuscleRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.reach_v0:ReachEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_muscleAct_v0.xml",
-        "target_reach_range": {
-            "IFtip": ((0.27, 0.1, 0.3), (0.1, -0.1, 0.1)),
-        },
-    },
-)
+register(id='FingerReachMuscleRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.reach_v0:ReachEnvV0',
+            max_episode_steps=10,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_muscleAct_v0.xml',
+                'target_reach_range': {'IFtip': ((0.27, .1, .3), (.1, -.1, .1)),},
+                'normalize_act': False,
+            }
+    )
 
 
 # Finger-Joint posing ==============================
-register(
-    id="FingerPoseMotorFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.pose_v0:PoseEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_motorAct_v0.xml",
-        "target_jnt_range": {
-            "IFadb": (0, 0),
-            "IFmcp": (0, 0),
-            "IFpip": (0.75, 0.75),
-            "IFdip": (0.75, 0.75),
-        },
-        "viz_site_targets": ("IFtip",),
-    },
-)
-register(
-    id="FingerPoseMotorRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.pose_v0:PoseEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_motorAct_v0.xml",
-        "target_jnt_range": {
-            "IFadb": (-0.2, 0.2),
-            "IFmcp": (-0.4, 1),
-            "IFpip": (0.1, 1),
-            "IFdip": (0.1, 1),
-        },
-        "viz_site_targets": ("IFtip",),
-    },
-)
-register(
-    id="FingerPoseMuscleFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.pose_v0:PoseEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_muscleAct_v0.xml",
-        "target_jnt_range": {
-            "IFadb": (0, 0),
-            "IFmcp": (0, 0),
-            "IFpip": (0.75, 0.75),
-            "IFdip": (0.75, 0.75),
-        },
-        "viz_site_targets": ("IFtip",),
-    },
-)
-register(
-    id="FingerPoseMuscleRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.pose_v0:PoseEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/finger/tendon_finger_muscleAct_v0.xml",
-        "target_jnt_range": {
-            "IFadb": (-0.2, 0.2),
-            "IFmcp": (-0.4, 1),
-            "IFpip": (0.1, 1),
-            "IFdip": (0.1, 1),
-        },
-        "viz_site_targets": ("IFtip",),
-    },
-)
+register(id='FingerPoseMotorFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_motorAct_v0.xml',
+                'target_jnt_range': {'IFadb':(0, 0),
+                                    'IFmcp':(0, 0),
+                                    'IFpip':(.75, .75),
+                                    'IFdip':(.75, .75)
+                                    },
+                'viz_site_targets': ('IFtip',),
+                'normalize_act': True
+            }
+    )
+register(id='FingerPoseMotorRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_motorAct_v0.xml',
+                'target_jnt_range': {'IFadb':(-.2, .2),
+                                    'IFmcp':(-.4, 1),
+                                    'IFpip':(.1, 1),
+                                    'IFdip':(.1, 1)
+                                    },
+                'viz_site_targets': ('IFtip',),
+                'normalize_act': True
+            }
+    )
+register(id='FingerPoseMuscleFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_muscleAct_v0.xml',
+                'target_jnt_range': {'IFadb':(0, 0),
+                                    'IFmcp':(0, 0),
+                                    'IFpip':(.75, .75),
+                                    'IFdip':(.75, .75)
+                                    },
+                'viz_site_targets': ('IFtip',),
+                'normalize_act': False,
+            }
+    )
+register(id='FingerPoseMuscleRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/assets/finger/tendon_finger_muscleAct_v0.xml',
+                'target_jnt_range': {'IFadb':(-.2, .2),
+                                    'IFmcp':(-.4, 1),
+                                    'IFpip':(.1, 1),
+                                    'IFdip':(.1, 1)
+                                    },
+                'viz_site_targets': ('IFtip',),
+                'normalize_act': False,
+            }
+    )
 
 # Hand-Joint posing ==============================
-register(
-    id="IFTHPoseMuscleRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.pose_v0:PoseEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir
-        + "/../../sims/neuromuscular_sim/hand/Index_Thumb_v0.xml",
-        "target_jnt_range": {
-            "MCP2_lateral": (-0.349066, 0.349066),
-            "MCP2_flex": (-0.174533, 1.5708),
-            "PIP_flex": (-0.0872665, 1.5708),
-            "DIP_flex": (-0.0872665, 1.5708),
-            "thumb_abd": (-0.785398, 0.261799),
-            "thumb_flex": (-0.785398, 1.5708),
-            "TCP2M_flex": (-0.17, 0.95),
-            "TCP2M2_flex": (-0.0872665, 1.5708),
-        },
-        "viz_site_targets": ("IFtip", "THtip"),
-        "normalize_act": False,
-        "reset_type": "none",  # none, init, random
-        "target_type": "generate",  # switch / generate
-    },
-)
+# OLD MODEL -- Please use new one
+register(id='IFTHPoseMuscleRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/../../sims/neuromuscular_sim/hand/Index_Thumb_v0.xml',
+                'target_jnt_range': {'MCP2_lateral': (-0.349066, 0.349066),
+                                    'MCP2_flex': (-0.174533, 1.5708),
+                                    'PIP_flex': (-0.0872665, 1.5708),
+                                    'DIP_flex': (-0.0872665, 1.5708),
+                                    'thumb_abd': (-0.785398, 0.261799),
+                                    'thumb_flex': (-0.785398, 1.5708),
+                                    'TCP2M_flex': (-0.17, 0.95),
+                                    'TCP2M2_flex': (-0.0872665, 1.5708)
+                                    },
+                'viz_site_targets': ('IFtip','THtip'),
+                'normalize_act': False,
+                'reset_type': 'none',           # none, init, random
+                'target_type': 'generate',      # switch / generate
+            }
+    )
 
-register(
-    id="HandPoseAMuscleFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.pose_v0:PoseEnvV0",
-    max_episode_steps=100,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_pose.xml",
-        "viz_site_targets": ("THtip", "IFtip", "MFtip", "RFtip", "LFtip"),
-        "target_jnt_value": np.array(
-            [
-                0,
-                0,
-                0,
-                -0.0904,
-                0.0824475,
-                -0.681555,
-                -0.514888,
-                0,
-                -0.013964,
-                -0.0458132,
-                0,
-                0.67553,
-                -0.020944,
-                0.76979,
-                0.65982,
-                0,
-                0,
-                0,
-                0,
-                0.479155,
-                -0.099484,
-                0.95831,
-                0,
-            ]
-        ),
-        "normalize_act": False,
-        "reset_type": "init",  # none, init, random
-        "target_type": "fixed",  # switch / generate/ fixed
-    },
+register(id='HandPoseAMuscleFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_pose.xml',
+                'viz_site_targets': ('THtip','IFtip','MFtip','RFtip','LFtip'),
+                'target_jnt_value': np.array([0, 0, 0, -0.0904, 0.0824475, -0.681555, -0.514888, 0, -0.013964, -0.0458132, 0, 0.67553, -0.020944, 0.76979, 0.65982, 0, 0, 0, 0, 0.479155, -0.099484, 0.95831, 0]),
+                'normalize_act': False,
+                'reset_type': "init",        # none, init, random
+                'target_type': 'fixed',      # switch / generate/ fixed
+            }
+    )
+
+jnt_namesHand=['pro_sup', 'deviation', 'flexion', 'cmc_abduction', 'cmc_flexion', 'mp_flexion', 'ip_flexion', 'mcp2_flexion', 'mcp2_abduction', 'pm2_flexion', 'md2_flexion', 'mcp3_flexion', 'mcp3_abduction', 'pm3_flexion', 'md3_flexion', 'mcp4_flexion', 'mcp4_abduction', 'pm4_flexion', 'md4_flexion', 'mcp5_flexion', 'mcp5_abduction', 'pm5_flexion', 'md5_flexion']
+
+ASL_qpos={}
+ASL_qpos[0]='0 0 0 0.5624 0.28272 -0.75573 -1.309 1.30045 -0.006982 1.45492 0.998897 1.26466 0 1.40604 0.227795 1.07614 -0.020944 1.46103 0.06284 0.83263 -0.14399 1.571 1.38248'.split(' ')
+ASL_qpos[1]='0 0 0 0.0248 0.04536 -0.7854 -1.309 0.366605 0.010473 0.269258 0.111722 1.48459 0 1.45318 1.44532 1.44532 -0.204204 1.46103 1.44532 1.48459 -0.2618 1.47674 1.48459'.split(' ')
+ASL_qpos[2]='0 0 0 0.0248 0.04536 -0.7854 -1.13447 0.514973 0.010473 0.128305 0.111722 0.510575 0 0.37704 0.117825 1.44532 -0.204204 1.46103 1.44532 1.48459 -0.2618 1.47674 1.48459'.split(' ')
+ASL_qpos[3]='0 0 0 0.3384 0.25305 0.01569 -0.0262045 0.645885 0.010473 0.128305 0.111722 0.510575 0 0.37704 0.117825 1.571 -0.036652 1.52387 1.45318 1.40604 -0.068068 1.39033 1.571'.split(' ')
+ASL_qpos[4]='0 0 0 0.6392 -0.147495 -0.7854 -1.309 0.637158 0.010473 0.128305 0.111722 0.510575 0 0.37704 0.117825 0.306345 -0.010472 0.400605 0.133535 0.21994 -0.068068 0.274925 0.01571'.split(' ')
+ASL_qpos[5]='0 0 0 0.3384 0.25305 0.01569 -0.0262045 0.645885 0.010473 0.128305 0.111722 0.510575 0 0.37704 0.117825 0.306345 -0.010472 0.400605 0.133535 0.21994 -0.068068 0.274925 0.01571'.split(' ')
+ASL_qpos[6]='0 0 0 0.6392 -0.147495 -0.7854 -1.309 0.637158 0.010473 0.128305 0.111722 0.510575 0 0.37704 0.117825 0.306345 -0.010472 0.400605 0.133535 1.1861 -0.2618 1.35891 1.48459'.split(' ')
+ASL_qpos[7]='0 0 0 0.524 0.01569 -0.7854 -1.309 0.645885 -0.006982 0.128305 0.111722 0.510575 0 0.37704 0.117825 1.28036 -0.115192 1.52387 1.45318 0.432025 -0.068068 0.18852 0.149245'.split(' ')
+ASL_qpos[8]='0 0 0 0.428 0.22338 -0.7854 -1.309 0.645885 -0.006982 0.128305 0.194636 1.39033 0 1.08399 0.573415 0.667675 -0.020944 0 0.06284 0.432025 -0.068068 0.18852 0.149245'.split(' ')
+ASL_qpos[9]='0 0 0 0.5624 0.28272 -0.75573 -1.309 1.30045 -0.006982 1.45492 0.998897 0.39275 0 0.18852 0.227795 0.667675 -0.020944 0 0.06284 0.432025 -0.068068 0.18852 0.149245'.split(' ')
+
+for k in ASL_qpos.keys():
+    register(id='HandPose'+str(k)+'MuscleFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+            max_episode_steps=100,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_pose.xml',
+                'viz_site_targets': ('THtip','IFtip','MFtip','RFtip','LFtip'),
+                'target_jnt_value': np.array(ASL_qpos[k],'float'),
+                'normalize_act': False,
+                'reset_type': "none",        # none, init, random
+                'target_type': 'fixed',      # switch / generate/ fixed
+            }
+    )
+
+m = np.array([ASL_qpos[i] for i in range(10)])
+Rpos = {}
+for i_n, n  in enumerate(jnt_namesHand):
+    Rpos[n]=m[:,i_n].astype(float)
+register(id='HandPoseMuscleRandom-v0',
+        entry_point='mj_envs.envs.biomechanics.pose_v0:PoseEnvV0',
+        max_episode_steps=100,
+        kwargs={
+            'model_path': curr_dir+'/assets/hand/2nd_hand_pose.xml',
+            'viz_site_targets': ('THtip','IFtip','MFtip','RFtip','LFtip'),
+            'target_jnt_range': Rpos,
+            'normalize_act': False,
+            'reset_type': "none",        # none, init, random
+            'target_type': 'fixed',      # switch / generate/ fixed
+        }
 )
 
 # Hand-Joint key turn ==============================
-register(
-    id="IFTHKeyTurnFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.key_turn_v0:KeyTurnFixedEnvV0",
-    max_episode_steps=200,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/Index_Thumb_keyturn_v0.xml",
-        "normalize_act": False,
-    },
-)
+register(id='IFTHKeyTurnFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.key_turn_v0:KeyTurnFixedEnvV0',
+            max_episode_steps=200,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_Index_Thumb_keyturn.xml',
+                'normalize_act': False
+            }
+    )
 
-register(
-    id="IFTHKeyTurnRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.key_turn_v0:KeyTurnRandomEnvV0",
-    max_episode_steps=200,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/Index_Thumb_keyturn_v0.xml",
-        "normalize_act": False,
-    },
-)
+register(id='IFTHKeyTurnRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.key_turn_v0:KeyTurnRandomEnvV0',
+            max_episode_steps=200,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_Index_Thumb_keyturn.xml',
+                'normalize_act': False
+            }
+    )
 
 
 # Hold objects ==============================
-register(
-    id="HandObjHoldFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.obj_hold_v0:ObjHoldFixedEnvV0",
-    max_episode_steps=75,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_hold.xml",
-        "normalize_act": False,
-    },
-)
+register(id='HandObjHoldFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.obj_hold_v0:ObjHoldFixedEnvV0',
+            max_episode_steps=75,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_hold.xml',
+                'normalize_act': False
+            }
+    )
 
-register(
-    id="HandObjHoldRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.obj_hold_v0:ObjHoldRandomEnvV0",
-    max_episode_steps=75,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_hold.xml",
-        "normalize_act": False,
-    },
-)
+register(id='HandObjHoldRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.obj_hold_v0:ObjHoldRandomEnvV0',
+            max_episode_steps=75,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_hold.xml',
+                'normalize_act': False
+            }
+    )
 
 
 # Pen twirl ==============================
-register(
-    id="HandPenTwirlFixed-v0",
-    entry_point="mj_envs.envs.biomechanics.pen_v0:PenTwirlFixedEnvV0",
-    max_episode_steps=50,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_pen.xml",
-        "normalize_act": True,
-        "frame_skip": 5,
-    },
-)
+register(id='HandPenTwirlFixed-v0',
+            entry_point='mj_envs.envs.biomechanics.pen_v0:PenTwirlFixedEnvV0',
+            max_episode_steps=50,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_pen.xml',
+                'normalize_act': False,
+                'frame_skip': 5,
+            }
+    )
 
-register(
-    id="HandPenTwirlRandom-v0",
-    entry_point="mj_envs.envs.biomechanics.pen_v0:PenTwirlRandomEnvV0",
-    max_episode_steps=50,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_pen.xml",
-        "normalize_act": True,
-        "frame_skip": 5,
-    },
-)
+register(id='HandPenTwirlRandom-v0',
+            entry_point='mj_envs.envs.biomechanics.pen_v0:PenTwirlRandomEnvV0',
+            max_episode_steps=50,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_pen.xml',
+                'normalize_act': False,
+                'frame_skip': 5,
+            }
+    )
 
 # Baoding ==============================
-register(
-    id="BaodingFixed-v1",
-    entry_point="mj_envs.envs.biomechanics.baoding_v1:BaodingFixedEnvV1",
-    max_episode_steps=200,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_baoding.xml",
-        "normalize_act": True,
-        "reward_option": 0,
-    },
-)
-register(
-    id="BaodingFixed4th-v1",
-    entry_point="mj_envs.envs.biomechanics.baoding_v1:BaodingFixedEnvV1",
-    max_episode_steps=200,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_baoding.xml",
-        "normalize_act": True,
-        "reward_option": 1,
-    },
-)
-register(
-    id="BaodingFixed8th-v1",
-    entry_point="mj_envs.envs.biomechanics.baoding_v1:BaodingFixedEnvV1",
-    max_episode_steps=200,
-    kwargs={
-        "model_path": curr_dir + "/assets/hand/2nd_hand_baoding.xml",
-        "normalize_act": True,
-        "reward_option": 2,
-    },
-)
+register(id='BaodingFixed-v1',
+            entry_point='mj_envs.envs.biomechanics.baoding_v1:BaodingFixedEnvV1',
+            max_episode_steps=200,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_baoding.xml',
+                'normalize_act': False,
+                'reward_option': 0,
+            }
+    )
+register(id='BaodingFixed4th-v1',
+            entry_point='mj_envs.envs.biomechanics.baoding_v1:BaodingFixedEnvV1',
+            max_episode_steps=200,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_baoding.xml',
+                'normalize_act': False,
+                'reward_option':1
+            }
+    )
+register(id='BaodingFixed8th-v1',
+            entry_point='mj_envs.envs.biomechanics.baoding_v1:BaodingFixedEnvV1',
+            max_episode_steps=200,
+            kwargs={
+                'model_path': curr_dir+'/assets/hand/2nd_hand_baoding.xml',
+                'normalize_act': False,
+                'reward_option': 2,
+            }
+    )

--- a/mj_envs/envs/biomechanics/assets/finger/tendon_finger_v0.xml
+++ b/mj_envs/envs/biomechanics/assets/finger/tendon_finger_v0.xml
@@ -48,7 +48,7 @@
 			<body name="middle">
 				<geom type="capsule" fromto="0.1 0 0.3 0.2 0 0.3" size=".015"/>
 				<geom name="mg2" type="cylinder" fromto="0.1 0.005 0.3 0.1 -0.005 0.3"
-					size="0.020" rgba=".5 .5 .9 .4"/>
+				size="0.020" rgba=".5 .5 .9 .4"/>
 				<joint name="IFpip" pos="0.1 0 0.3"/>
 				<site name="ms4" pos="0.12 0 0.315"/>
 				<site name="ms5" pos="0.13 0 0.32"/>
@@ -61,7 +61,7 @@
 				<body name="distal">
 					<geom type="capsule" fromto="0.2 0 0.3 0.27 0 0.3" size=".012"/>
 					<geom name="dg3" type="cylinder" fromto="0.2 0.005 0.3 0.2 -0.005 0.3"
-						size="0.018" rgba=".5 .5 .9 .4"/>
+					size="0.018" rgba=".5 .5 .9 .4"/>
 					<geom type="ellipsoid" pos=".27 0 .310" size=".012 .009 .0025" rgba="1 .9 .9 1"/>
 					<joint name="IFdip" pos="0.2 0 0.3"/>
 					<site name="ds6" pos="0.22 0 0.31"/>

--- a/mj_envs/envs/biomechanics/assets/hand/2nd_hand_Index_Thumb_keyturn.xml
+++ b/mj_envs/envs/biomechanics/assets/hand/2nd_hand_Index_Thumb_keyturn.xml
@@ -1,6 +1,7 @@
-<mujoco model="Index Thumb Model for turning key task">
+<mujoco model="2nd hand model - Index Thumb Model for turning key task">
     <compiler meshdir='../../../../sims/neuromuscular_sim/hand/'/>
-    <include file="../../../../sims/neuromuscular_sim/hand/Index_Thumb_v0.xml"/>
+    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_index_thumb_v0.1.3.xml"/>
+    
     <default>
         <default class="key">
             <geom rgba=".6 .6 .5 1"/>
@@ -8,7 +9,7 @@
     </default>
 
     <worldbody>
-        <body name="key" pos="-.14 -.06 .17" childclass="key" euler="0 0 .4">
+        <body name="key" pos="-.25 -.24 0.98" childclass="key" euler="0 0 .4">
             <geom type="ellipsoid" size=".030 .030 .004" name="keyhead"/>
             <geom type="capsule" size="0.005 0.070" pos="-.045 0 0" euler="0 1.57 0"/>
             <geom type="box" size=".015 .010 .004" pos="-.1 0.008 0"/>
@@ -17,7 +18,7 @@
         </body>
     </worldbody>
 
-    <keyframe>
+    <!-- <keyframe>
         <key qpos='-0.017455 -0.174595 0.865249 0.882818 0.182 -0.031352 -0.17 0.592621 0'/>
-    </keyframe>
+    </keyframe> -->
 </mujoco>

--- a/mj_envs/envs/biomechanics/assets/hand/2nd_hand_baoding.xml
+++ b/mj_envs/envs/biomechanics/assets/hand/2nd_hand_baoding.xml
@@ -1,7 +1,7 @@
 <mujoco model="2nd hand model for pen reorient">
 
     <compiler meshdir='../../../../sims/neuromuscular_sim/hand/'/>
-    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.xml"/>
+    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.1.3.xml"/>
 
     <option timestep="0.0025"/>
 

--- a/mj_envs/envs/biomechanics/assets/hand/2nd_hand_hold.xml
+++ b/mj_envs/envs/biomechanics/assets/hand/2nd_hand_hold.xml
@@ -1,7 +1,7 @@
 <mujoco model="2nd hand model for object grasps">
 
     <compiler meshdir='../../../../sims/neuromuscular_sim/hand/'/>
-    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.xml"/>
+    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.1.3.xml"/>
 
     <worldbody>
         <site name="goal" size="0.04" pos="-.2 -.2 1" rgba="0 1 0 .2"/>

--- a/mj_envs/envs/biomechanics/assets/hand/2nd_hand_pen.xml
+++ b/mj_envs/envs/biomechanics/assets/hand/2nd_hand_pen.xml
@@ -1,7 +1,7 @@
 <mujoco model="2nd hand model for pen reorient">
 
     <compiler meshdir='../../../../sims/neuromuscular_sim/hand/'/>
-    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.xml"/>
+    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.1.3.xml"/>
 
     <default>
 		<default class="pen">

--- a/mj_envs/envs/biomechanics/assets/hand/2nd_hand_pose.xml
+++ b/mj_envs/envs/biomechanics/assets/hand/2nd_hand_pose.xml
@@ -1,7 +1,7 @@
 <mujoco model="2nd hand model for object grasps">
 
     <compiler meshdir='../../../../sims/neuromuscular_sim/hand/'/>
-    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.xml"/>
+    <include file="../../../../sims/neuromuscular_sim/hand/2nd_Hand_Model_full_hand_v0.1.3.xml"/>
 
     <worldbody>
         <site name="THtip_target" pos="0 0 0.002" size="0.005" rgba="0.8 0 0 .8"/>

--- a/mj_envs/envs/biomechanics/baoding_v1.py
+++ b/mj_envs/envs/biomechanics/baoding_v1.py
@@ -33,21 +33,14 @@ class BaodingFixedEnvV1(BaseV0):
        'bonus':1.0
     }
 
-    def __init__(self,
-                model_path:str,
-                normalize_act:bool,
-                reward_option:int,
-                seed = None,
-                obs_keys:list = DEFAULT_OBS_KEYS,
-                weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                **kwargs):
+    def __init__(self, model_path:str, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -56,22 +49,10 @@ class BaodingFixedEnvV1(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    reward_option=reward_option, 
-                    rwd_viz=False,
-                    seed=seed)
+        self._setup(**kwargs)
 
 
-    def _setup(self,
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            normalize_act,
-            reward_option,
-            rwd_viz,
-            seed,
-        ):
+    def _setup(self, reward_option, **kwargs):
 
         # user parameters
         self.reward_option = reward_option
@@ -98,11 +79,9 @@ class BaodingFixedEnvV1(BaseV0):
         self.target1_sid = self.sim.model.site_name2id('target1_site')
         self.target2_sid = self.sim.model.site_name2id('target2_site')
 
-        super()._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    rwd_viz=rwd_viz,
-                    seed=seed)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       **kwargs)
 
 
     def step(self, a):

--- a/mj_envs/envs/biomechanics/base_v0.py
+++ b/mj_envs/envs/biomechanics/base_v0.py
@@ -9,15 +9,11 @@ class BaseV0(env_base.MujocoEnv):
         super().__init__(model_path)
 
     def _setup(self,
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            sites:list = None,
-            frame_skip = 10,
-            seed = None,
-            is_hardware = False,
-            config_path = None,
-            rwd_viz = False,
-            normalize_act = True,
+               obs_keys:list,
+               weighted_reward_keys:dict,
+               sites:list = None,
+               frame_skip = 10,
+               **kwargs,
         ):
 
         if self.sim.model.na>0 and 'act' not in obs_keys:
@@ -32,13 +28,9 @@ class BaseV0(env_base.MujocoEnv):
                 self.target_sids.append(self.sim.model.site_name2id(site+'_target'))
         
         super()._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    frame_skip=frame_skip, 
-                    seed=seed, 
-                    is_hardware=is_hardware,
-                    config_path=config_path,
-                    rwd_viz=rwd_viz,
-                    normalize_act=normalize_act)
+                       weighted_reward_keys=weighted_reward_keys, 
+                       frame_skip=frame_skip, 
+                       **kwargs)
 
 
     # step the simulation forward

--- a/mj_envs/envs/biomechanics/base_v0.py
+++ b/mj_envs/envs/biomechanics/base_v0.py
@@ -5,6 +5,12 @@ import gym
 
 class BaseV0(env_base.MujocoEnv):
 
+    muscle_condition = ''
+    which_muscles = []
+    which_gain_muscles = []
+    MVC_rest = []
+    f_load = {}
+
     def __init__(self, model_path):
         super().__init__(model_path)
 
@@ -26,17 +32,50 @@ class BaseV0(env_base.MujocoEnv):
             for site in sites:
                 self.tip_sids.append(self.sim.model.site_name2id(site))
                 self.target_sids.append(self.sim.model.site_name2id(site+'_target'))
-        
-        super()._setup(obs_keys=obs_keys, 
-                       weighted_reward_keys=weighted_reward_keys, 
-                       frame_skip=frame_skip, 
-                       **kwargs)
 
+        # TODO: pick it from kwargs
+        self.which_muscles = [2, 3, 4]
+        self.which_gain_muscles = [100, 100, 100]
+        # self.muscle_condition = muscle_condition
+        # for muscle weakness we assume that a weaker muscle has a
+        # reduced maximum force
+        if self.muscle_condition == 'weakness':
+            for mus_idx in self.which_muscles:
+                self.sim.model.actuator_gainprm[mus_idx,2] = self.which_gain_muscles[mus_idx]*sim.model.actuator_gainprm[mus_idx,2]
+        # for muscle fatigue we used the model from
+        # Liang Ma, Damien Chablat, Fouad Bennis, Wei Zhang
+        # A new simple dynamic muscle fatigue model and its validation
+        # International Journal of Industrial Ergonomics 39 (2009) 211–220
+        elif self.muscle_condition == 'fatigue':
+            self.f_load = {}
+            self.MVC_rest = {}
+            for mus_idx in range(self.sim.model.actuator_gainprm.shape[0]):
+                self.f_load[mus_idx] = []
+                self.MVC_rest[mus_idx] = self.sim.model.actuator_gainprm[mus_idx,2]
+
+        super()._setup(obs_keys=obs_keys,
+                    weighted_reward_keys=weighted_reward_keys,
+                    frame_skip=frame_skip,
+                    **kwargs)
+
+        if self.sim.model.na:
+            assert self.normalize_act is False, "Explict action remapping is performed for envs with muscle actuator. Turn act_normalized to False to remove default linear remapping to action limits"
 
     # step the simulation forward
     def step(self, a):
-        if self.normalize_act:
+        # Override default linear action remapping for Muscle actuators. Remapping must respect actuator limits
+        if self.sim.model.na:
             a = 1.0/(1.0+np.exp(-5.0*(a-0.5)))
+
+        if self.muscle_condition == 'fatigue':
+            for mus_idx in range(self.sim.model.actuator_gainprm.shape[0]):
+                self.f_load[mus_idx].append(self.sim.data.actuator_moment[mus_idx,1].copy())
+                # import ipdb; ipdb.set_trace()
+                f_int = np.sum(self.f_load[mus_idx])/self.MVC_rest[mus_idx]
+                f_cem = self.MVC_rest[mus_idx]*np.exp(f_int)
+                self.sim.model.actuator_gainprm[mus_idx,2] = f_cem
+                self.sim_obsd.model.actuator_gainprm[mus_idx,2] = f_cem
+
         return super().step(a=a)
 
     # def mj_viewer_setup(self):

--- a/mj_envs/envs/biomechanics/key_turn_v0.py
+++ b/mj_envs/envs/biomechanics/key_turn_v0.py
@@ -16,20 +16,14 @@ class KeyTurnFixedEnvV0(BaseV0):
         'penalty':-25.0
     }
 
-    def __init__(self,
-                model_path:str,
-                normalize_act:bool,
-                seed = None,
-                obs_keys:list = DEFAULT_OBS_KEYS,
-                weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                **kwargs):
+    def __init__(self, model_path:str, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -38,29 +32,19 @@ class KeyTurnFixedEnvV0(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    rwd_viz=False, 
-                    seed=seed)
+        self._setup(**kwargs)
 
-    def _setup(self,
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            normalize_act,
-            rwd_viz,
-            seed,
-        ):
+
+    def _setup(self, **kwargs):
+
         self.keyhead_sid = self.sim.model.site_name2id("keyhead")
         self.IF_sid = self.sim.model.site_name2id("IFtip")
         self.TH_sid = self.sim.model.site_name2id("THtip")   
         # self.init_qpos = self.sim.model.key_qpos[0]    
 
-        super()._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    rwd_viz=rwd_viz,
-                    seed=seed)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       **kwargs)
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/biomechanics/obj_hold_v0.py
+++ b/mj_envs/envs/biomechanics/obj_hold_v0.py
@@ -14,20 +14,14 @@ class ObjHoldFixedEnvV0(BaseV0):
         "penalty": -10,
     }
 
-    def __init__(self,
-                model_path:str,
-                normalize_act:bool,
-                seed = None,
-                obs_keys:list = DEFAULT_OBS_KEYS,
-                weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                **kwargs):
+    def __init__(self, model_path:str, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -36,28 +30,17 @@ class ObjHoldFixedEnvV0(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    rwd_viz=False,
-                    seed=seed)
+        self._setup(**kwargs)
 
-    def _setup(self,
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            normalize_act,
-            rwd_viz,
-            seed,
-        ):
+
+    def _setup(self, **kwargs):
 
         self.object_sid = self.sim.model.site_name2id("object")
         self.goal_sid = self.sim.model.site_name2id("goal")
 
-        super()._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    rwd_viz=rwd_viz,
-                    seed=seed)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       **kwargs)
 
 
     def get_obs_vec(self):

--- a/mj_envs/envs/biomechanics/pen_v0.py
+++ b/mj_envs/envs/biomechanics/pen_v0.py
@@ -19,21 +19,14 @@ class PenTwirlFixedEnvV0(BaseV0):
         'bonus':10.0
     }
 
-    def __init__(self,
-                model_path:str,
-                normalize_act:bool,
-                frame_skip:int,
-                seed = None,
-                obs_keys:list = DEFAULT_OBS_KEYS,
-                weighted_reward_keys:list = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                **kwargs):
+    def __init__(self, model_path:str, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -42,21 +35,10 @@ class PenTwirlFixedEnvV0(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(obs_keys=obs_keys, 
-                    weighted_reward_keys=weighted_reward_keys, 
-                    normalize_act=normalize_act, 
-                    frame_skip=frame_skip, 
-                    rwd_viz=False,
-                    seed=seed)
+        self._setup(**kwargs)
 
-    def _setup(self,
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            normalize_act,
-            frame_skip,
-            rwd_viz,
-            seed,
-        ):
+
+    def _setup(self, **kwargs):
 
         self.target_obj_bid = self.sim.model.body_name2id("target")
         self.S_grasp_sid = self.sim.model.site_name2id('S_grasp')
@@ -69,12 +51,10 @@ class PenTwirlFixedEnvV0(BaseV0):
         self.pen_length = np.linalg.norm(self.sim.model.site_pos[self.obj_t_sid] - self.sim.model.site_pos[self.obj_b_sid])
         self.tar_length = np.linalg.norm(self.sim.model.site_pos[self.tar_t_sid] - self.sim.model.site_pos[self.tar_b_sid])
 
-        super()._setup(obs_keys=obs_keys, 
-            weighted_reward_keys=weighted_reward_keys, 
-            normalize_act=normalize_act, 
-            rwd_viz=rwd_viz,
-            frame_skip=frame_skip,
-            seed=seed)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       **kwargs)
+
 
     def get_obs_vec(self):
         # qpos for hand, xpos for obj, xpos for target

--- a/mj_envs/envs/biomechanics/pose_v0.py
+++ b/mj_envs/envs/biomechanics/pose_v0.py
@@ -14,24 +14,14 @@ class PoseEnvV0(BaseV0):
         "penalty": -50,
     }
 
-    def __init__(self,
-                model_path:str,
-                seed = None, 
-                viz_site_targets:tuple = None,  # site to use for targets visualization []
-                target_jnt_range:dict = None,   # joint ranges as tuples {name:(min, max)}_nq
-                target_jnt_value:list = None,   # desired joint vector [des_qpos]_nq
-                reset_type = "init",            # none; init; random
-                target_type = "generate",       # generate; switch; fixed
-                obs_keys:list = DEFAULT_OBS_KEYS,
-                weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                **kwargs):
+    def __init__(self, model_path:str, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -40,28 +30,16 @@ class PoseEnvV0(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(viz_site_targets=viz_site_targets, 
-                target_jnt_range=target_jnt_range, 
-                target_jnt_value=target_jnt_value,
-                reset_type=reset_type,
-                target_type=target_type,
-                obs_keys=obs_keys,
-                weighted_reward_keys=weighted_reward_keys,
-                seed=seed,
-            )
+        self._setup(**kwargs)
+
 
     def _setup(self,
-            viz_site_targets:tuple, 
-            target_jnt_range:dict,
-            target_jnt_value:list,  
-            reset_type,           
-            target_type, 
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            frame_skip = 10,
-            seed = None,
-            is_hardware = False,
-            config_path = None,
+               target_jnt_range:dict=None,
+               target_jnt_value:list=None,  
+               reset_type="none",           
+               target_type="generate", 
+               frame_skip = 10,
+               **kwargs,
         ):
 
         self.reset_type = reset_type
@@ -79,13 +57,11 @@ class PoseEnvV0(BaseV0):
         else:
             self.target_jnt_value = target_jnt_value
 
-        super()._setup(obs_keys=obs_keys, 
-                weighted_reward_keys=weighted_reward_keys, 
-                sites=viz_site_targets, 
-                frame_skip=frame_skip, 
-                seed=seed, 
-                is_hardware=is_hardware, 
-                config_path=config_path)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       frame_skip=frame_skip, 
+                       **kwargs)
+
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/biomechanics/reach_v0.py
+++ b/mj_envs/envs/biomechanics/reach_v0.py
@@ -15,21 +15,14 @@ class ReachEnvV0(BaseV0):
         "penalty": -50,
     }
 
-    def __init__(self,
-                model_path:str,
-                target_reach_range:dict,
-                seed = None,
-                obs_keys:list = DEFAULT_OBS_KEYS,
-                weighted_reward_keys:dict = DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                **kwargs,
-            ):
+    def __init__(self, model_path:str, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__ 
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we 
@@ -38,31 +31,23 @@ class ReachEnvV0(BaseV0):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
         
-        self._setup(target_reach_range=target_reach_range, 
-                obs_keys=obs_keys, 
-                weighted_reward_keys=weighted_reward_keys,
-                seed=seed)
+        self._setup(**kwargs)
 
 
     def _setup(self,
-            target_reach_range:dict,
-            obs_keys:list,
-            weighted_reward_keys:dict,
-            frame_skip = 10,
-            seed = None,
-            is_hardware = False,
-            config_path = None,
+               target_reach_range:dict,
+               frame_skip = 10,
+               **kwargs,
         ):
 
         self.target_reach_range = target_reach_range
 
-        super()._setup(obs_keys=obs_keys, 
-                weighted_reward_keys=weighted_reward_keys, 
-                sites=self.target_reach_range.keys(), 
-                frame_skip=frame_skip, 
-                seed=seed, 
-                is_hardware=is_hardware, 
-                config_path=config_path)
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS, 
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS, 
+                       sites=self.target_reach_range.keys(), 
+                       frame_skip=frame_skip, 
+                       **kwargs)
+
 
     def get_obs_vec(self):
         self.obs_dict['t'] = np.array([self.sim.data.time])

--- a/mj_envs/envs/env_base.py
+++ b/mj_envs/envs/env_base.py
@@ -50,7 +50,7 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
     def _setup(self,
                obs_keys,
                weighted_reward_keys,
-               reward_mode = "dense",             
+               reward_mode = "dense",
                frame_skip = 1,
                normalize_act = True,
                obs_range = (-10, 10),
@@ -68,8 +68,8 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
         self.rwd_viz = rwd_viz
 
         # resolve robot config
-        self.robot = Robot(mj_sim=self.sim, 
-                           random_generator=self.np_random, 
+        self.robot = Robot(mj_sim=self.sim,
+                           random_generator=self.np_random,
                            **kwargs)
 
         #resolve action space
@@ -102,7 +102,7 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
             linear_jnt_ids = self.sim.model.jnt_type>1
             self.init_qpos[linear_jnt_qposids] = np.mean(self.sim.model.jnt_range[linear_jnt_ids], axis=1)
 
-        return 
+        return
 
     def step(self, a):
         """

--- a/mj_envs/envs/env_base.py
+++ b/mj_envs/envs/env_base.py
@@ -48,18 +48,15 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
         ObsVecDict.__init__(self)
 
     def _setup(self,
-            obs_keys,
-            weighted_reward_keys,
-            reward_mode = "dense",             
-            frame_skip = 1,
-            normalize_act = True,
-            obs_range = (-10, 10),
-            seed = None,
-            act_mode = "pos",
-            is_hardware = False,
-            config_path = None,
-            rwd_viz = False,
-            robot_name:str = 'default_robot', 
+               obs_keys,
+               weighted_reward_keys,
+               reward_mode = "dense",             
+               frame_skip = 1,
+               normalize_act = True,
+               obs_range = (-10, 10),
+               seed = None,
+               rwd_viz = False,
+               **kwargs,
         ):
 
         if self.sim is None or self.sim_obsd is None:
@@ -72,12 +69,8 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
 
         # resolve robot config
         self.robot = Robot(mj_sim=self.sim, 
-                        robot_name=robot_name,
-                        random_generator=self.np_random, 
-                        act_mode=act_mode,
-                        is_hardware=is_hardware,
-                        config_path = config_path,
-                    )
+                           random_generator=self.np_random, 
+                           **kwargs)
 
         #resolve action space
         self.frame_skip = frame_skip

--- a/mj_envs/envs/env_base.py
+++ b/mj_envs/envs/env_base.py
@@ -63,6 +63,7 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
             raise InvalidStateErr("sim and sim_obsd must be instantiated for setup to run")
 
         # seed the random number generator
+        self.input_seed = None
         self.seed(seed)
         self.mujoco_render_frames = False
         self.rwd_viz = rwd_viz
@@ -183,8 +184,8 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
         obs_dict = self.obsvec2obsdict(paths["observations"])
         rwd_dict = self.get_reward_dict(obs_dict)
 
-        rewards = reward_dict[self.rwd_mode]
-        done = reward_dict['done']
+        rewards = rwd_dict[self.rwd_mode]
+        done = rwd_dict['done']
         # time align rewards. last step is redundant
         done[...,:-1] = done[...,1:]
         rewards[...,:-1] = rewards[...,1:]
@@ -239,8 +240,13 @@ class MujocoEnv(gym.Env, gym.utils.EzPickle, ObsVecDict):
         """
         Set random number seed
         """
+        self.input_seed = seed
         self.np_random, seed = gym.utils.seeding.np_random(seed)
         return [seed]
+
+
+    def get_input_seed(self):
+        return self.input_seed
 
 
     def reset(self, reset_qpos=None, reset_qvel=None):

--- a/mj_envs/envs/fm/base_v0.py
+++ b/mj_envs/envs/fm/base_v0.py
@@ -1,4 +1,5 @@
 from time import process_time
+import gym
 import numpy as np
 from mj_envs.envs import env_base
 from mj_envs.utils.xml_utils import reassign_parent
@@ -15,8 +16,7 @@ class FMBase(env_base.MujocoEnv):
         "bonus": 4.0,
         "penalty": -50,
     }
-
-    def __init__(self, model_path, config_path, target_pose, **kwargs):
+    def __init__(self, model_path, **kwargs):
 
         curr_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -28,26 +28,30 @@ class FMBase(env_base.MujocoEnv):
         with open(processed_model_path, 'w') as file:
             file.write(processed_xml)
 
-        self.sim = env_base.get_sim(model_path=processed_model_path)
-        self.sim_obsd = env_base.get_sim(model_path=processed_model_path)
+        # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
+        # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
+        # at the leaf level, when we do inheritance like we do here.
+        # kwargs is needed at the top level to account for injection of __class__ keyword.
+        # Also see: https://github.com/openai/gym/pull/1497
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
+
+        # This two step construction is required for pickling to work correctly. All arguments to all __init__
+        # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we
+        # first construct the inheritance chain, which is just __init__ calls all the way down, with env_base
+        # creating the sim / sim_obsd instances. Next we run through "setup"  which relies on sim / sim_obsd
+        # created in __init__ to complete the setup.
+        super().__init__(model_path=processed_model_path)
         os.remove(processed_model_path)
 
+        self._setup(**kwargs)
+
+    def _setup(self, target_pose, **kwargs):
         self.target_pose = target_pose
 
-        # get env
-        env_base.MujocoEnv.__init__(self,
-                                sim = self.sim,
-                                sim_obsd = self.sim_obsd,
-                                frame_skip = 40,
-                                config_path = config_path,
-                                obs_keys = self.DEFAULT_OBS_KEYS,
-                                rwd_keys_wt = self.DEFAULT_RWD_KEYS_AND_WEIGHTS,
-                                rwd_mode = "dense",
-                                act_mode = "pos",
-                                act_normalized = True,
-                                is_hardware = False,
-                                **kwargs)
-
+        super()._setup(obs_keys=self.DEFAULT_OBS_KEYS,
+                       weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS,
+                       frame_skip=40,
+                       **kwargs)
 
     def get_obs_dict(self, sim):
         obs_dict = {}

--- a/mj_envs/envs/relay_kitchen/kitchen_multitask_v2.py
+++ b/mj_envs/envs/relay_kitchen/kitchen_multitask_v2.py
@@ -90,28 +90,14 @@ class KitchenBase(env_base.MujocoEnv):
         "approach": 0.5,
     }
 
-    def __init__(
-        self,
-        model_path,
-        config_path,
-        robot_jnt_names,
-        obj_jnt_names,
-        obj_interaction_site,
-        goal,
-        interact_site,
-        seed=None,
-        obj_init=None,
-        obs_keys_wt=DEFAULT_OBS_KEYS_AND_WEIGHTS,
-        weighted_reward_keys=DEFAULT_RWD_KEYS_AND_WEIGHTS,
-        **kwargs,
-    ):
+    def __init__(self, model_path, **kwargs):
 
         # EzPickle.__init__(**locals()) is capturing the input dictionary of the init method of this class.
         # In order to successfully capture all arguments we need to call gym.utils.EzPickle.__init__(**locals())
         # at the leaf level, when we do inheritance like we do here.
         # kwargs is needed at the top level to account for injection of __class__ keyword.
         # Also see: https://github.com/openai/gym/pull/1497
-        gym.utils.EzPickle.__init__(**locals())
+        gym.utils.EzPickle.__init__(self, model_path, **kwargs)
 
         # This two step construction is required for pickling to work correctly. All arguments to all __init__
         # calls must be pickle friendly. Things like sim / sim_obsd are NOT pickle friendly. Therefore we
@@ -120,38 +106,22 @@ class KitchenBase(env_base.MujocoEnv):
         # created in __init__ to complete the setup.
         super().__init__(model_path=model_path)
 
-        self._setup(
-            config_path=config_path,
-            robot_jnt_names=robot_jnt_names,
-            obj_jnt_names=obj_jnt_names,
-            obj_interaction_site=obj_interaction_site,
-            goal=goal,
-            interact_site=interact_site,
-            obj_init=obj_init,
-            obs_keys_wt=obs_keys_wt,
-            weighted_reward_keys=weighted_reward_keys,
-            seed=seed,
-        )
+        self._setup(**kwargs)
 
-    def _setup(
-        self,
-        config_path,
-        robot_jnt_names,
-        obj_jnt_names,
-        obj_interaction_site,
-        goal,
-        interact_site,
-        obj_init,
-        obs_keys_wt,
-        weighted_reward_keys,
-        seed,
-        frame_skip=40,
-        reward_mode="dense",
-        act_mode="vel",
-        normalize_act=True,
-        is_hardware=False,
-        robot_name="Franka_kitchen_sim",
-        obs_range=(-8, 8),
+
+    def _setup(self,
+               robot_jnt_names,
+               obj_jnt_names,
+               obj_interaction_site,
+               goal,
+               interact_site,
+               obj_init,
+               # different defaults than what is used in env_base and robot
+               frame_skip=40,
+               obs_range=(-8, 8),
+               act_mode="vel",
+               robot_name="Franka_kitchen_sim",
+               **kwargs,
     ):
 
         if VIZ:
@@ -205,17 +175,13 @@ class KitchenBase(env_base.MujocoEnv):
         self.set_goal(goal=goal, interact_site=interact_site)
 
         super()._setup(
-            obs_keys=list(obs_keys_wt.keys()),
-            weighted_reward_keys=weighted_reward_keys,
-            reward_mode=reward_mode,
+            obs_keys=list(self.DEFAULT_OBS_KEYS_AND_WEIGHTS.keys()),
+            weighted_reward_keys=self.DEFAULT_RWD_KEYS_AND_WEIGHTS,
             frame_skip=frame_skip,
-            normalize_act=normalize_act,
-            seed=seed,
             act_mode=act_mode,
-            is_hardware=is_hardware,
-            config_path=config_path,
             obs_range=obs_range,
             robot_name=robot_name,
+            **kwargs,
         )
 
         self.init_qpos[:] = self.sim.model.key_qpos[0].copy()
@@ -380,26 +346,22 @@ class KitchenFrankaFixed(KitchenBase):
     def __init__(
         self,
         model_path,
-        config_path,
         robot_jnt_names=ROBOT_JNT_NAMES,
         obj_jnt_names=OBJ_JNT_NAMES,
         obj_interaction_site=INTERACTION_SITES,
         goal=None,
         interact_site="end_effector",
-        seed=None,
         obj_init=None,
         **kwargs,
     ):
         KitchenBase.__init__(
             self,
             model_path=model_path,
-            config_path=config_path,
             robot_jnt_names=robot_jnt_names,
             obj_jnt_names=obj_jnt_names,
             obj_interaction_site=obj_interaction_site,
             goal=goal,
             interact_site=interact_site,
-            seed=seed,
             obj_init=obj_init,
             **kwargs,
         )

--- a/mj_envs/robot/robot.py
+++ b/mj_envs/robot/robot.py
@@ -42,6 +42,7 @@ class Robot():
                 sensor_cache_maxsize = 5,   # cache size for sensors
                 noise_scale = 0,            # scale for sensor noise
                 random_generator = None,    # random number generator
+                **kwargs,
             ):
 
         self.name = robot_name+'(sim)' if is_hardware is None else robot_name+'(hdr)'

--- a/mj_envs/robot/robot.py
+++ b/mj_envs/robot/robot.py
@@ -451,7 +451,14 @@ class Robot():
         processed_controls = controls.copy()
         act_id = -1
         for name, device in self.robot_config.items():
-            if name != "default_robot":
+            if name == "default_robot":
+                if self._act_mode == "pos":
+                    if normalized:
+                        processed_controls = np.mean(self.sim.model.actuator_ctrlrange, axis=-1)+ \
+                            controls*(self.sim.model.actuator_ctrlrange[:,1]-self.sim.model.actuator_ctrlrange[:,0])/2.0
+                else:
+                    raise TypeError("only pos act supported")
+            else:
                 for actuator in device['actuator']:
                     act_id += 1
                     in_id = actuator['sim_id']

--- a/mj_envs/tests/envs/arms/test_arms.py
+++ b/mj_envs/tests/envs/arms/test_arms.py
@@ -17,7 +17,8 @@ ENVIRONMENT_IDS = (
 
 @pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
 def test_serialize_deserialize(environment_id):
-    env1 = gym.make(environment_id, seed=123)
+    input_seed = 123
+    env1 = gym.make(environment_id, seed=input_seed)
     obs_dict_1 = env1.get_obs_dict(env1.env.sim)
     reward_dict_1 = env1.get_reward_dict(obs_dict_1)
     assert len(obs_dict_1) > 0
@@ -26,12 +27,17 @@ def test_serialize_deserialize(environment_id):
     assert len(obs) > 0
     infos1 = env1.env.get_env_infos()
     assert len(infos1) > 0
+    assert env1.get_input_seed() == input_seed
     
     env1.reset()
 
     env2 = pickle.loads(pickle.dumps(env1))
     env2.reset()
+    assert env2.get_input_seed() == input_seed
 
+    assert env1.get_input_seed() == env2.get_input_seed(), {
+        env1.get_input_seed(), env2.get_input_seed()
+    }
     assert env1.action_space == env2.action_space, (
         env1.action_space, env2.action_space
     )

--- a/mj_envs/tests/envs/biomechanics/test_biomechanics.py
+++ b/mj_envs/tests/envs/biomechanics/test_biomechanics.py
@@ -30,7 +30,8 @@ ENVIRONMENT_IDS = (
 
 @pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
 def test_serialize_deserialize(environment_id):
-    env1 = gym.make(environment_id, seed=123)
+    input_seed = 123
+    env1 = gym.make(environment_id, seed=input_seed)
     obs_dict_1 = env1.get_obs_dict(env1.env.sim)
     reward_dict_1 = env1.get_reward_dict(obs_dict_1)
     assert len(obs_dict_1) > 0
@@ -39,12 +40,17 @@ def test_serialize_deserialize(environment_id):
     assert len(obs) > 0
     infos1 = env1.env.get_env_infos()
     assert len(infos1) > 0
+    assert env1.get_input_seed() == input_seed
     
     env1.reset()
 
     env2 = pickle.loads(pickle.dumps(env1))
     env2.reset()
+    assert env2.get_input_seed() == input_seed
 
+    assert env1.get_input_seed() == env2.get_input_seed(), {
+        env1.get_input_seed(), env2.get_input_seed()
+    }
     assert env1.action_space == env2.action_space, (
         env1.action_space, env2.action_space
     )
@@ -61,4 +67,3 @@ def test_serialize_deserialize(environment_id):
 
     env1.env.step(numpy.zeros(env1.env.sim.model.nu))
     env2.env.step(numpy.zeros(env2.env.sim.model.nu))
-

--- a/mj_envs/tests/envs/relay_kitchen/test_kitchen.py
+++ b/mj_envs/tests/envs/relay_kitchen/test_kitchen.py
@@ -41,32 +41,39 @@ ENVIRONMENT_IDS = (
 
 @pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
 def test_serialize_deserialize(environment_id):
-    env1 = gym.make(environment_id, seed=123)
+    input_seed = 123
+    env1 = gym.make(environment_id, seed=input_seed)
     obs_dict_1 = env1.get_obs_dict(env1.env.sim)
     reward_dict_1 = env1.get_reward_dict(obs_dict_1)
     assert len(obs_dict_1) > 0
     assert len(reward_dict_1) > 0
-    obs = env1.env.get_obs()
+    obs = env1.env.get_obs()    
     assert len(obs) > 0
     infos1 = env1.env.get_env_infos()
     assert len(infos1) > 0
-
+    assert env1.get_input_seed() == input_seed
+    
     env1.reset()
 
     env2 = pickle.loads(pickle.dumps(env1))
     env2.reset()
+    assert env2.get_input_seed() == input_seed
 
+    assert env1.get_input_seed() == env2.get_input_seed(), {
+        env1.get_input_seed(), env2.get_input_seed()
+    }
     assert env1.action_space == env2.action_space, (
-        env1.action_space,
-        env2.action_space,
+        env1.action_space, env2.action_space
     )
-    assert (env1.get_obs() == env2.get_obs()).all(), (env1.get_obs(), env2.get_obs())
+    assert (env1.get_obs() == env2.get_obs()).all(), (
+        env1.get_obs(), env2.get_obs()
+    )
 
     obs_dict_2 = env2.get_obs_dict(env2.env.sim)
     reward_dict_2 = env2.get_reward_dict(obs_dict_2)
     infos2 = env2.env.get_env_infos()
     assert len(obs_dict_1) == len(obs_dict_2), (obs_dict_1, obs_dict_2)
-    assert len(reward_dict_1) == len(reward_dict_2), (reward_dict_1, reward_dict_2)
+    assert len(reward_dict_1) == len(reward_dict_2), (reward_dict_1, reward_dict_2)  
     assert len(infos1) == len(infos2), (infos1, infos2)
 
     env1.env.step(numpy.zeros(env1.env.sim.model.nu))

--- a/mj_envs/tests/test_envs.py
+++ b/mj_envs/tests/test_envs.py
@@ -1,75 +1,66 @@
 import unittest
 
 import gym
-import mj_envs # noqa
+import mj_envs
 import numpy as np
-
 
 class TestEnvs(unittest.TestCase):
 
-    def check_envs(self, module_name, env_names, lite=True):
+    def check_envs(self, module_name, env_names, lite=False, seed=1234):
         print("\nTesting module:: ", module_name)
         for env_name in env_names:
             print("Testing env: ", env_name)
             # test init
             env = gym.make(env_name)
+            env.seed(seed)
+
             # test reset
             env.env.reset()
             # test obs vec
-            # obs = env.env.get_obs()
+            obs = env.env.get_obs()
 
             if not lite:
                 # test obs dict
-                obs_dict_sim = env.env.get_obs_dict(env.env.sim)
-                obs_dict_sim_obsd = env.env.get_obs_dict(env.env.sim_obsd)
-
-                # for key in obs_dict_sim.keys():
-                # check if the env is partially observable
-                for key in env.env.obs_keys:
-                    if (obs_dict_sim[key] != obs_dict_sim_obsd[key]).any():
-                        print("WARNING: {} environment is partially observable. This can happen if there aren't enough sensors defined in the robot config file or if you are using sensor noise. Please make sure this is a conscious choice, and not an oversight".format(env_name))
-                        print("\tobs_dict_sim[{}]: {}".format(key, obs_dict_sim[key]))
-                        print("\tobs_dict_sim_obsd[{}]: {}\n".format(key, obs_dict_sim_obsd[key]))
-
+                obs_dict = env.env.get_obs_dict(env.env.sim)
                 # test rewards
-                rwd = env.env.get_reward_dict(obs_dict_sim)
+                rwd = env.env.get_reward_dict(obs_dict)
 
                 # test vector => dict upgrade
                 # print(env.env.get_obs() - env.env.get_obs_vec())
                 # assert (env.env.get_obs() == env.env.get_obs_vec()).all(), "check vectorized computations"
 
             # test env infos
-            # infos = env.env.get_env_infos()
+            infos = env.env.get_env_infos()
 
             # test step (everything together)
             observation, _reward, done, _info = env.env.step(np.zeros(env.env.sim.model.nu))
+            del(env)
 
-    # Franka Kitchen
-    def test_frankakitchen(self):
+    # Biomechanics
+    def test_biomechanics(self):
         env_names = [
-            # 'kitchen-v0',
-            'kitchen-v2',
-            'kitchen_micro_open-v2',
-            'kitchen_rdoor_open-v2',
-            'kitchen_ldoor_open-v2',
-            'kitchen_sdoor_open-v2',
-            'kitchen_light_on-v2',
-            'kitchen_knob4_on-v2',
-            'kitchen_knob3_on-v2',
-            'kitchen_knob2_on-v2',
-            'kitchen_knob1_on-v2',
-            'kitchen-v3', 'kitchen_close-v3',
-            'kitchen_micro_open-v3', 'kitchen_micro_close-v3',
-            'kitchen_rdoor_open-v3', 'kitchen_rdoor_close-v3',
-            'kitchen_ldoor_open-v3', 'kitchen_ldoor_close-v3',
-            'kitchen_sdoor_open-v3', 'kitchen_sdoor_close-v3',
-            'kitchen_light_on-v3', 'kitchen_light_off-v3',
-            'kitchen_knob4_on-v3', 'kitchen_knob4_off-v3',
-            'kitchen_knob3_on-v3', 'kitchen_knob3_off-v3',
-            'kitchen_knob2_on-v3', 'kitchen_knob2_off-v3',
-            'kitchen_knob1_on-v3', 'kitchen_knob1_off-v3',
-            ]
-        self.check_envs('Franka Kitchen', env_names, lite=False)
+            'FingerReachMotorFixed-v0', 'FingerReachMotorRandom-v0',
+            'FingerReachMuscleFixed-v0', 'FingerReachMuscleRandom-v0',
+
+            'FingerPoseMotorFixed-v0', 'FingerPoseMotorRandom-v0',
+            'FingerPoseMuscleFixed-v0', 'FingerPoseMuscleRandom-v0',
+
+            'IFTHPoseMuscleRandom-v0',
+            'IFTHKeyTurnFixed-v0', 'IFTHKeyTurnRandom-v0',
+
+            'IFTHPoseMuscleRandom-v0', 'HandPoseAMuscleFixed-v0',
+            'IFTHKeyTurnFixed-v0', 'IFTHKeyTurnRandom-v0',
+            'HandObjHoldFixed-v0', 'HandObjHoldRandom-v0',
+            'HandPenTwirlFixed-v0', 'HandPenTwirlRandom-v0',
+
+            'BaodingFixed-v1', 'BaodingFixed4th-v1', 'BaodingFixed8th-v1',
+
+            'HandPoseMuscleRandom-v0'
+        ]
+
+        for k in range(10): env_names+=['HandPose'+str(k)+'MuscleFixed-v0']
+
+        self.check_envs('Biomechanics', env_names)
 
     # Arms
     def test_arms(self):
@@ -83,14 +74,15 @@ class TestEnvs(unittest.TestCase):
             ]
         self.check_envs('Arms', env_names, lite=False)
 
-    # Functional Manipulation
-    def test_fm(self):
+    # Hand Manipulation Suite
+    def test_hand_manipulation_suite(self):
         env_names = [
-            # 'DManusReachFixed-v0',
-            'FMReachFixed-v0'
-            ]
-        self.check_envs('Functional Manipulation', env_names)
-
+        'pen-v0',
+        'door-v0',
+        'hammer-v0',
+        'relocate-v0',
+        ]
+        self.check_envs('Hand Manipulation', env_names, lite=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/mj_envs/utils/visualize_env.py
+++ b/mj_envs/utils/visualize_env.py
@@ -1,7 +1,6 @@
 import gym
-import mj_envs
+import mj_envs #even if unused it is needed to register the environments
 import click
-import gym
 import numpy as np
 import pickle
 
@@ -9,8 +8,8 @@ DESC = '''
 Helper script to visualize policy.\n
 USAGE:\n
     Visualizes policy on the env\n
-    $ python visualize_policy.py --env_name door-v0 \n
-    $ python visualize_policy.py --env_name door-v0 --policy my_policy.pickle --mode evaluation --episodes 10 \n
+    $ python visualize_env.py --env_name door-v0 \n
+    $ python visualize_env.py --env_name door-v0 --policy my_policy.pickle --mode evaluation --episodes 10 \n
 '''
 
 # Random policy
@@ -27,11 +26,18 @@ class rand_policy():
 @click.option('-p', '--policy', type=str, help='absolute path of the policy file', default=None)
 @click.option('-m', '--mode', type=str, help='exploration or evaluation mode for policy', default='evaluation')
 @click.option('-s', '--seed', type=int, help='seed for generating environment instances', default=123)
-@click.option('-n', '--episodes', type=int, help='number of episodes to visualize', default=10)
+@click.option('-n', '--num_episodes', type=int, help='number of episodes to visualize', default=10)
+@click.option('-r', '--render', type=click.Choice(['onscreen', 'offscreen']), help='visualize onscreen or offscreen', default='onscreen')
+@click.option('-f', '--filename', type=str, default='newvideo', help=('The name to save the rendered video as.'))
 
-def main(env_name, policy, mode, seed, episodes):
+def main(env_name, policy, mode, seed, num_episodes, render, filename):
+
+    # seed and load environments
+    np.random.seed(seed)
     env = gym.make(env_name)
     env.seed(seed)
+
+    # resolve policy
     if policy is not None:
         pi = pickle.load(open(policy, 'rb'))
     else:
@@ -39,7 +45,22 @@ def main(env_name, policy, mode, seed, episodes):
         mode = 'exploration'
 
     # render policy
-    env.visualize_policy(pi, num_episodes=episodes, horizon=env.spec.max_episode_steps, mode=mode)
+    if render == 'onscreen':
+        env.visualize_policy(
+            policy=pi,
+            num_episodes=num_episodes,
+            horizon=env.spec.max_episode_steps,
+            mode=mode)
+    elif render == 'offscreen':
+        env.visualize_policy_offscreen(
+            policy=pi,
+            horizon=env.spec.max_episode_steps,
+            num_episodes=num_episodes,
+            frame_size=(640,480),
+            mode=mode,
+            filename=filename)
 
 if __name__ == '__main__':
     main()
+
+

--- a/mj_envs/utils/xml_utils.py
+++ b/mj_envs/utils/xml_utils.py
@@ -2,7 +2,7 @@ import xml.etree.ElementTree as ET
 from xml.dom import minidom
 import sys
 
-def parse_xml_with_comments(xml_path: str=None, xml_str: str=None):
+def parse_xml_with_comments(xml_path: str):
     """
     Parse XML while preserving comments.
         Input:
@@ -10,25 +10,18 @@ def parse_xml_with_comments(xml_path: str=None, xml_str: str=None):
         Outputs:
             tree    : Parsed tree
     """
-
-    if xml_str:
-        tree = ET.ElementTree(ET.fromstring(xml_str))
-    elif xml_path:
-        if sys.version_info[0]+0.1*sys.version_info[1]< 3.8:
-            # python version < 3.8: Create a custom parser
-            class CommentedTreeBuilder(ET.TreeBuilder):
-                def comment(self, data):
-                    self.start(ET.Comment, {})
-                    self.data(data)
-                    self.end(ET.Comment)
-            tree = ET.parse(xml_path, parser=ET.XMLParser(target=CommentedTreeBuilder()))
-        else:
-            # python version >= 3.8: Use default parser with corrent configuration
-            parser_with_comments = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
-            tree = ET.parse(xml_path, parser=parser_with_comments)
+    if sys.version_info[0]+0.1*sys.version_info[1]< 3.8:
+        # python version < 3.8: Create a custom parser
+        class CommentedTreeBuilder(ET.TreeBuilder):
+            def comment(self, data):
+                self.start(ET.Comment, {})
+                self.data(data)
+                self.end(ET.Comment)
+        tree = ET.parse(xml_path, parser=ET.XMLParser(target=CommentedTreeBuilder()))
     else:
-        raise TypeError("Both xml_path and xml_str can't be None")
-
+        # python version >= 3.8: Use default parser with corrent configuration
+        parser_with_comments = ET.XMLParser(target=ET.TreeBuilder(insert_comments=True))
+        tree = ET.parse(xml_path, parser=parser_with_comments)
     return tree
 
 
@@ -46,20 +39,9 @@ def get_xml_str(tree: ET.ElementTree=None,
     """
     node = tree.getroot() if node is None else node
     # ET.dump(node)  # debug print
-
+    xmlstr = ET.tostring(node, encoding='unicode', method='xml')
     if pretty:
-        # remove previous formatting
-        node.tail = ""
-        node.text = ""
-        for elem in node.iter():
-            elem.tail=""
-            if elem.tag != ET.Comment:
-                elem.text = ""
-        xmlstr = ET.tostring(node, encoding='unicode', method='xml')
         xmlstr = minidom.parseString(xmlstr).toprettyxml(indent="\t")
-    else:
-        xmlstr = ET.tostring(node, encoding='unicode', method='xml')
-
     return(xmlstr)
 
 
@@ -94,41 +76,28 @@ def merge_xmls( receiver_xml:str,
     elif destination == "tree":
         return receiver_tree
 
-def reassign_parent( xml_path: str=None,
-                    xml_str: str=None,
-                    receiver_node=None,
-                    donor_node=None,
-                    destination="str"):
-    """
-    Merge XMLs preserving MuJoCo structure
-        Input:
-            xml_path        : XML_filepath receiving data
-            xml_str         : XML_str receiving data (higher priority over XML_filepath)
-            receiver_node   : node_name where donor gets attached
-            donor_node      : list of donor-nodes to attached (TODO)
-            destination     : str / tree
 
-        Output:
-            merged_xml      : str or tree format
-    """
-    # import ipdb; ipdb.set_trace()
+# test_xml = ET.parse("tendon_finger_v0.xml")
+# print_xml(test_xml)
+# xmlstr = merge_xmls(receiver_xml="tendon_finger_v0.xml",
+#         donor_xml="tendon_finger_muscleAct.xml")
 
-    # find elements
-    xml_tree = parse_xml_with_comments(xml_path=xml_path, xml_str=xml_str)
-    parent_elem = xml_tree.find(".//body[@name='{}']".format(receiver_node))
-    assert parent_elem, "Parent node:{} not found".format(parent_elem)
+# with open("output_xmlstr.xml", "w") as f:
+#     f.write(xmlstr)
 
-    child_elem = xml_tree.find(".//body[@name='{}']".format(donor_node))
-    assert child_elem, "Child node:{} not found".format(child_elem)
 
-    child_parent_elem = xml_tree.find(".//body[@name='{}']...".format(donor_node))
-    assert child_parent_elem, "Child's parent node:{} not found".format(child_elem)
+# finger_tree = ET.parse("tendon_finger_v0.xml")
+# foceAct_tree = ET.parse("tendon_finger_forceAct.xml")
 
-    # move child
-    parent_elem.append(child_elem)
-    child_parent_elem.remove(child_elem)
+# root = finger_tree.getroot()
+# # for child in root:
+#     # print(child.tag, child.attrib)
 
-    if destination == "str":
-        return get_xml_str(xml_tree)
-    elif destination == "tree":
-        return xml_tree
+# wb = finger_tree.find('worldbody')
+# include_root = foceAct_tree.getroot()
+# for child in include_root:
+#     root.append(child)
+
+# ET.dump(root)
+# # import ipdb; ipdb.set_trace()
+


### PR DESCRIPTION
## WHY

In this context, there are two views to how class constructor arguments should be handled.

1. Explicitly pass every parameter. 
    - This ensures that we can nail down behavior as much as we can. It is possible to have different behaviors based on argument values, however it is not possible to introduce change of behavior by arbitrarily injecting parameters.
    - Downside to this approach is that introducing new parameters requires a code change
2. Just pass kwargs along the class inheritance chain
    - Easy extensibility. If a class deep inside the inheritance chain, say `Robot` in our case, which is instantiated and managed from `env_base.py` needs an additional parameter, there is no need to touch intermediate classes.
    - However it is possible to introduce behavior change by passing additional arguments. Lots of action at a distance is possible. 

In case of `mj_envs` we prefer the `kwargs` route as these envs can change quite a bit during experimentation and nailing down every parameter is not developer friendly. 

## TEST PLAN

```
(mjrl-env) giriman@devfair0439:~/ubuntu/rl/mj_envs$ pytest mj_envs/tests/envs/
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.7.10, pytest-5.0.1, py-1.10.0, pluggy-0.13.1
rootdir: /private/home/giriman/ubuntu/rl/mj_envs
plugins: hydra-core-1.1.0rc1
collected 55 items                                                                                                                                                                                                           

mj_envs/tests/envs/arms/test_arms.py ......                                                                                                                                                                            [ 10%]
mj_envs/tests/envs/biomechanics/test_biomechanics.py ...................                                                                                                                                               [ 45%]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py ..............................                                                                                                                                        [100%]

====================================================================================================== warnings summary ======================================================================================================
/private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:26
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:26: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    _MAX_FLOAT = np.maximum_sctype(np.float)

/private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:27
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/transforms3d/quaternions.py:27: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    _FLOAT_EPS = np.finfo(np.float).eps

mj_envs/tests/envs/arms/test_arms.py::test_serialize_deserialize[FrankaReachFixed-v0]
mj_envs/tests/envs/arms/test_arms.py::test_serialize_deserialize[FrankaReachRandom-v0]
mj_envs/tests/envs/arms/test_arms.py::test_serialize_deserialize[FrankaPushFixed-v0]
mj_envs/tests/envs/arms/test_arms.py::test_serialize_deserialize[FrankaPushRandom-v0]
mj_envs/tests/envs/arms/test_arms.py::test_serialize_deserialize[FetchReachFixed-v0]
mj_envs/tests/envs/arms/test_arms.py::test_serialize_deserialize[FetchReachRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMotorRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerReachMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMotorFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMotorRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[FingerPoseMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHPoseMuscleRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPoseAMuscleFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHKeyTurnFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[IFTHKeyTurnRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandObjHoldFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandObjHoldRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPenTwirlFixed-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[HandPenTwirlRandom-v0]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed-v1]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed4th-v1]
mj_envs/tests/envs/biomechanics/test_biomechanics.py::test_serialize_deserialize[BaodingFixed8th-v1]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_micro_open-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_rdoor_open-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_ldoor_open-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_sdoor_open-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_light_on-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob4_on-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob3_on-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob2_on-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob1_on-v2]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_close-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_micro_open-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_micro_close-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_rdoor_open-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_rdoor_close-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_ldoor_open-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_ldoor_close-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_sdoor_open-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_sdoor_close-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_light_on-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_light_off-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob4_on-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob4_off-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob3_on-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob3_off-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob2_on-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob2_off-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob1_on-v3]
mj_envs/tests/envs/relay_kitchen/test_kitchen.py::test_serialize_deserialize[kitchen_knob1_off-v3]
  /private/home/giriman/.conda/envs/mjrl-env/lib/python3.7/site-packages/gym/logger.py:30: UserWarning: WARN: Box bound precision lowered by casting to float32
    warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================== 55 passed, 57 warnings in 152.83 seconds ==========================================================================================
(mjrl-env) giriman@devfair0439:~/ubuntu/rl/mj_envs$ 
```