### PR TITLE
Streamline OSX Installation Process 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,26 @@ License :: Under Apache License, Version 2.0 (the "License"); you may not use th
 0. We recommend installaition within a conda environement. If you don't have one yet, create one using
 ```
 conda create -n robohive python=3
+conda activate robohive
 ```
 
 1. Clone this repo on branch `branch_name` with pre-populated submodule dependencies
 
-a. Most users -
-```
-git clone -c submodule.mj_envs/sims/neuromuscular_sim.update=none --branch <branch_name> --recursive https://github.com/vikashplus/mj_envs.git
-```
-b. myoSuite developers: you must have access to neuromuscular_sim(private repo) -
-```
-git clone --branch <branch_name> --recursive https://github.com/vikashplus/mj_envs.git
-```
+   a. Most users -
+   ```
+   git clone -c submodule.mj_envs/sims/neuromuscular_sim.update=none --branch v0.4dev  --recursive https://github.com/vikashplus/mj_envs.git
+   ```
+
+   b. myoSuite developers: you must have access to neuromuscular_sim(private repo) -
+   ```
+   git clone --branch <branch_name> --recursive https://github.com/vikashplus/mj_envs.git
+   ```
+
 2. Install package using `pip`
 ```
 $ cd mj_envs
-$ pip install -e .
+$ pip install -e .[a0] #with a0 binding for realworld robot
+$ pip install -e .     #simulation only
 ```
 **OR**
 Add repo to pythonpath by updating `~/.bashrc` or `~/.bash_profile`

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(fname):
 
 setup(
     name='mj_envs',
-    version='0.3.0',
+    version='0.4.0',
     packages=find_packages(),
     description='environments simulated in MuJoCo',
     long_description=read('README.md'),

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,14 @@ setup(
         'matplotlib',
         'ffmpeg',
         'absl-py',
-        'pycapnp==1.1.0',
         'r3m @ git+https://github.com/facebookresearch/r3m.git',
         # 'data_tools @ git+https://github.com/fairinternal/data_tools.git',
         'h5py==3.7.0',
-        'alephzero', # real_sense subscribers dependency
     ],
+    extras_require={
+      'a0': [
+        'pycapnp==1.1.0',
+        'alephzero', # real_sense subscribers dependency
+        ]
+    }
 )


### PR DESCRIPTION
* bump version to v0.4, update readme
* move a0 deps into option packages as they do not install on OSX platform and only used for realworld robot connection.