### PR TITLE
RoboSet user comment logging fix

### DIFF
--- a/mj_envs/logger/roboset_logger.py
+++ b/mj_envs/logger/roboset_logger.py
@@ -51,7 +51,7 @@ class RoboSet_Trace(Trace):
             dataset['config'] = config
 
         if 'user_cmt' in path.keys():
-            dataset['config/solved'] = float(path['user_cmt'])
+            dataset['config/solved'] = np.array(np.float16(path['user_cmt']))
 
         return dataset
 


### PR DESCRIPTION
When saving user comment, h5py would throw a scaler dataset error. 